### PR TITLE
Raise an error at server startup if sqlfluff-templater-dbt is installed

### DIFF
--- a/src/dbt_osmosis/main.py
+++ b/src/dbt_osmosis/main.py
@@ -302,8 +302,9 @@ def serve(
     """Runs a lightweight server compatible with dbt-power-user and convenient for interactively
     running or compile dbt SQL queries with two simple endpoints accepting POST messages"""
     if importlib.util.find_spec('sqlfluff_templater_dbt'):
-        raise ValueError("sqlfluff-templater-dbt is not compatible with dbt-osmosis server. "
-                         "Please uninstall it to continue.")
+        logger().error("sqlfluff-templater-dbt is not compatible with dbt-osmosis server. "
+                       "Please uninstall it to continue.")
+        sys.exit(1)
 
     logger().info(":water_wave: Executing dbt-osmosis\n")
 

--- a/src/dbt_osmosis/main.py
+++ b/src/dbt_osmosis/main.py
@@ -1,4 +1,5 @@
 import functools
+import importlib.util
 import multiprocessing
 import subprocess
 import sys
@@ -300,6 +301,10 @@ def serve(
 ):
     """Runs a lightweight server compatible with dbt-power-user and convenient for interactively
     running or compile dbt SQL queries with two simple endpoints accepting POST messages"""
+    if importlib.util.find_spec('sqlfluff_templater_dbt'):
+        raise ValueError("sqlfluff-templater-dbt is not compatible with dbt-osmosis server. "
+                         "Please uninstall it to continue.")
+
     logger().info(":water_wave: Executing dbt-osmosis\n")
 
     def _register_project():


### PR DESCRIPTION
It's easy to make a mistake and install `sqlfluff-templater-dbt` in the same virtualenv as `dbt-osmosis`. This doesn't work, so check for this at server startup and fail if it's present.