### PR TITLE
Allow for documenting Struct Fields - BigQuery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Intellij Files
+.idea
+.DS_STORE


### PR DESCRIPTION
## Description 

This PR updates the get_columns method to account for the fact that in BigQuery Projects, the columns can be nested structures. This is accounted for by flattening these structs to ensure that every name is accounted for. This logic will be used when the type returned by the adapter is a BigQuery Column with the flatten method. Otherwise, the column names will be returned without flattening.

## Impact 
Fixes #32 