### PR TITLE
[nit] remove SchemaFileOrganizationPattern

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -46,14 +46,6 @@ class YamlHandler(ruamel.yaml.YAML):
         self.default_flow_style = False
 
 
-class SchemaFileOrganizationPattern(str, Enum):
-    SchemaYaml = "schema.yml"
-    FolderYaml = "folder.yml"
-    ModelYaml = "model.yml"
-    UnderscoreModelYaml = "_model.yml"
-    SchemaModelYaml = "schema/model.yml"
-
-
 class SchemaFileLocation(BaseModel):
     target: Path
     current: Optional[Path] = None


### PR DESCRIPTION
@z3z1ma With the following change, `SchemaFileOrganizationPattern` is no longer referenced anywhere (Investigated by `git grep`). Therefore, remove the `SchemaFileOrganizationPattern` by this pull request.

- https://github.com/z3z1ma/dbt-osmosis/commit/703fe300c8f83bbba29983307d4caf4d08d7e351
- https://github.com/z3z1ma/dbt-osmosis/commit/4717ebd427cf434b041f1316c79d5aaa93cf0a55