### PR TITLE
Allow reading from catalog for document

### DIFF
--- a/src/dbt_osmosis/main.py
+++ b/src/dbt_osmosis/main.py
@@ -249,11 +249,20 @@ def organize(
     is_flag=True,
     help="If specified, will return a non-zero exit code if any files are changed.",
 )
+@click.option(
+    "--catalog-file",
+    type=click.Path(exists=True),
+    help=(
+        "If specified, will read the list of columns from the catalog.json file instead of querying"
+        " the warehouse."
+    ),
+)
 @click.argument("models", nargs=-1)
 def document(
     target: Optional[str] = None,
     project_dir: Optional[str] = None,
     profiles_dir: Optional[str] = None,
+    catalog_file: Optional[str] = None,
     fqn: Optional[str] = None,
     force_inheritance: bool = False,
     dry_run: bool = False,
@@ -280,6 +289,7 @@ def document(
         fqn=fqn,
         dry_run=dry_run,
         models=models,
+        catalog_file=catalog_file,
     )
 
     # Propagate documentation & inject/remove schema file columns to align with model in database
@@ -723,7 +733,8 @@ def compile(
     profiles_dir: Optional[str] = None,
     target: Optional[str] = None,
 ):
-    """Compiles dbt SQL statement writing an OsmosisCompileResult | OsmosisErrorContainer to stdout"""
+    """Compiles dbt SQL statement writing an OsmosisCompileResult | OsmosisErrorContainer to stdout
+    """
     from dbt_osmosis.vendored.dbt_core_interface.project import (
         ServerCompileResult,
         ServerError,

--- a/src/dbt_osmosis/main.py
+++ b/src/dbt_osmosis/main.py
@@ -114,11 +114,20 @@ def shared_opts(func: Callable) -> Callable:
     is_flag=True,
     help="If specified, will return a non-zero exit code if any files are changed.",
 )
+@click.option(
+    "--catalog-file",
+    type=click.Path(exists=True),
+    help=(
+        "If specified, will read the list of columns from the catalog.json file instead of querying"
+        " the warehouse."
+    ),
+)
 @click.argument("models", nargs=-1)
 def refactor(
     target: Optional[str] = None,
     project_dir: Optional[str] = None,
     profiles_dir: Optional[str] = None,
+    catalog_file: Optional[str] = None,
     fqn: Optional[str] = None,
     force_inheritance: bool = False,
     dry_run: bool = False,
@@ -146,6 +155,7 @@ def refactor(
         fqn=fqn,
         dry_run=dry_run,
         models=models,
+        catalog_file=catalog_file,
     )
 
     # Conform project structure & bootstrap undocumented models injecting columns


### PR DESCRIPTION
Fixes #57 

First shot at adding support for providing a catalog file as input.

Things that you might want me to change:
- using `col.lower()` - I had to use it to make the code work with my own project on Snowflake where the YML files are defined with lowercase columns but are stored as uppercase in `catalog.json`
- the parameter name called `--catalog-file` or how we want users to be able to pick between offline (catalog) vs online (connecting to the warehouse)
- how I handle `parts` to match the function parameter and catalog file