### PR TITLE
fixed upstream knowledge in case the key is lower case

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -983,7 +983,7 @@ class DbtYamlManager(DbtProject):
         inheritables = ("description", "tags", "meta")
         changes_committed = 0
         for column in undocumented_columns:
-            prior_knowledge = knowledge.get(column, {})
+            prior_knowledge = knowledge.get(column, False) or knowledge.get(column.lower(), False) or {}
             progenitor = prior_knowledge.pop("progenitor", "Unknown")
             prior_knowledge = {k: v for k, v in prior_knowledge.items() if k in inheritables}
             if not prior_knowledge:


### PR DESCRIPTION
Fix #58.
When upstream column name is written lowercase in yaml file, prior_knowledge cannot get each items and return empty dictionary.
This is because the column names in catalog.json are uppercase in Snowflake.