### PR TITLE
Allow to keep root level column name that contains nested fields

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -351,9 +351,9 @@ class DbtYamlManager(DbtProject):
                     return columns
                 try:
                     for c in self.adapter.get_columns_in_relation(table):
+                        columns.append(self.column_casing(c.name))
                         if hasattr(c, "flatten"):
-                            columns.append(self.column_casing(c.name))
-                        columns.extend([self.column_casing(exp.name) for exp in getattr(c, "flatten", lambda: [c])()])
+                            columns.extend([self.column_casing(exp.name) for exp in c.flatten()])
                 except Exception as error:
                     logger().info(
                         (

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -350,11 +350,10 @@ class DbtYamlManager(DbtProject):
                     )
                     return columns
                 try:
-                    columns = [
-                        self.column_casing(exp.name)
-                        for c in self.adapter.get_columns_in_relation(table)
-                        for exp in getattr(c, "flatten", lambda: [c])()
-                    ]
+                    for c in self.adapter.get_columns_in_relation(table):
+                        if hasattr(c, "flatten"):
+                            columns.append(self.column_casing(c.name))
+                        columns.extend([self.column_casing(exp.name) for exp in getattr(c, "flatten", lambda: [c])()])
                 except Exception as error:
                     logger().info(
                         (


### PR DESCRIPTION
## Why
I'm using dbt-osmosis to maintain the metadata for BigQuery, especially for column description. We can write column description with nested fields like

```yaml
version: 2
models:
  - name: example_table
    columns:
      - name: root_column
        description: "Description of root_column"
      - name: root_column.sub1
        description: "Description of root_column.sub1"
      - name: root_column.sub2
        description: "Description of root_column.sub2"
```

After running `dbt-osmosis yaml refactor models/example_table`, the information of the root level column disappeared 😭 .

```yaml
version: 2
models:
  - name: example_table
    columns:
      - name: root_column.sub1
        description: "Description of root_column.sub1"
      - name: root_column.sub2
        description: "Description of root_column.sub2"
```

Data users need the description of the root column.

## What
I added a root level column name that contains nested fields.

## Reference
- https://github.com/z3z1ma/dbt-osmosis/pull/35