### PR TITLE
Add options for `--skip-add-tags` and `--skip-merge-meta`

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -109,6 +109,8 @@ class DbtYamlManager(DbtProject):
         dry_run: bool = False,
         models: Optional[List[str]] = None,
         skip_add_columns: bool = False,
+        skip_add_tags: bool = False,
+        skip_merge_meta: bool = False,
     ):
         """Initializes the DbtYamlManager class."""
         super().__init__(target, profiles_dir, project_dir, threads)
@@ -117,6 +119,8 @@ class DbtYamlManager(DbtProject):
         self.dry_run = dry_run
         self.catalog_file = catalog_file
         self.skip_add_columns = skip_add_columns
+        self.skip_add_tags = skip_add_tags
+        self.skip_merge_meta = skip_merge_meta
 
         if len(list(self.filtered_models())) == 0:
             logger().warning(
@@ -979,7 +983,13 @@ class DbtYamlManager(DbtProject):
         """Update undocumented columns with prior knowledge in node and model simultaneously
         THIS MUTATES THE NODE AND MODEL OBJECTS so that state is always accurate"""
         knowledge = self.get_node_columns_with_inherited_knowledge(node)
-        inheritables = ("description", "tags", "meta")
+
+        inheritables = ["description"]
+        if not self.skip_add_tags:
+            inheritables.append("tags")
+        if not self.skip_merge_meta:
+            inheritables.append("meta")
+
         changes_committed = 0
         for column in undocumented_columns:
             prior_knowledge = knowledge.get(column, False) or knowledge.get(column.lower(), False) or {}

--- a/src/dbt_osmosis/main.py
+++ b/src/dbt_osmosis/main.py
@@ -130,6 +130,16 @@ def shared_opts(func: Callable) -> Callable:
         " document your models without adding columns present in the database."
     ),
 )
+@click.option(
+    "--skip-add-tags",
+    is_flag=True,
+    help="If specified, we will skip adding tags to the models.",
+)
+@click.option(
+    "--skip-merge-meta",
+    is_flag=True,
+    help="If specified, we will skip merging meta to the models.",
+)
 @click.argument("models", nargs=-1)
 def refactor(
     target: Optional[str] = None,
@@ -141,6 +151,8 @@ def refactor(
     dry_run: bool = False,
     check: bool = False,
     skip_add_columns: bool = False,
+    skip_add_tags: bool = False,
+    skip_merge_meta: bool = False,
     models: Optional[List[str]] = None,
 ):
     """Executes organize which syncs yaml files with database schema and organizes the dbt models
@@ -166,6 +178,8 @@ def refactor(
         models=models,
         catalog_file=catalog_file,
         skip_add_columns=skip_add_columns,
+        skip_add_tags=skip_add_tags,
+        skip_merge_meta=skip_merge_meta,
     )
 
     # Conform project structure & bootstrap undocumented models injecting columns
@@ -206,6 +220,16 @@ def refactor(
         "If specified, we will skip adding columns to the models. This is useful if you want to"
         " document your models without adding columns present in the database."
     ),
+)
+@click.option(
+    "--skip-add-tags",
+    is_flag=True,
+    help="If specified, we will skip adding tags to the models.",
+)
+@click.option(
+    "--skip-merge-meta",
+    is_flag=True,
+    help="If specified, we will skip merging meta to the models.",
 )
 @click.argument("models", nargs=-1)
 def organize(
@@ -295,6 +319,16 @@ def organize(
         " document your models without adding columns present in the database."
     ),
 )
+@click.option(
+    "--skip-add-tags",
+    is_flag=True,
+    help="If specified, we will skip adding tags to the models.",
+)
+@click.option(
+    "--skip-merge-meta",
+    is_flag=True,
+    help="If specified, we will skip merging meta to the models.",
+)
 @click.argument("models", nargs=-1)
 def document(
     target: Optional[str] = None,
@@ -307,6 +341,8 @@ def document(
     check: bool = False,
     models: Optional[List[str]] = None,
     skip_add_columns: bool = False,
+    skip_add_tags: bool = False,
+    skip_merge_meta: bool = False,
 ):
     """Column level documentation inheritance for existing models
 
@@ -330,6 +366,8 @@ def document(
         models=models,
         catalog_file=catalog_file,
         skip_add_columns=skip_add_columns,
+        skip_add_tags=skip_add_tags,
+        skip_merge_meta=skip_merge_meta,
     )
 
     # Propagate documentation & inject/remove schema file columns to align with model in database


### PR DESCRIPTION
dbt-osmosis inherits not only column descriptions but also (adding) tags and (merging) meta. Sometimes we only want to inherit column descriptions. So I added options `--skip-add-tags` and `--skip-merge-meta`.