### PR TITLE
[nit] Upgrade the minimum Python version to 3.8 in docs

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -12,7 +12,7 @@ Get started by **running dbt-osmosis**.
 
 ### What you'll need
 
-- [Python](https://www.python.org/downloads/) (3.7+)
+- [Python](https://www.python.org/downloads/) (3.8+)
 - [dbt](https://docs.getdbt.com/docs/core/installation) (1.0.0+)
 - [pipx](https://pypa.github.io/pipx/installation/)
 - An existing dbt project (or you can play with it using [jaffle shop](https://github.com/dbt-labs/jaffle_shop_duckdb))


### PR DESCRIPTION
I noticed that the minimum Python version mentioned in the documentation has not been updated. It is updated by https://github.com/z3z1ma/dbt-osmosis/commit/e59809093ba1710a3c878ba53473495969545994.