### PR TITLE
Database specification for source bootstrapping+fix

### DIFF
--- a/docs/docs/tutorial-yaml/configuration.md
+++ b/docs/docs/tutorial-yaml/configuration.md
@@ -49,11 +49,13 @@ vars:
     <source_name>: <path>
     <source_name>:
       path: <path>
+      database: <database>
       schema: <schema>
 ```
 
 - `<source_name>` is the name of a source in your `dbt_project.yml` file.
 - `<path>` is the path to the YAML file that will be generated for the source. This path is relative to the root of your dbt project models directory.
+- `<database>` is the database that will be used for the source. If not specified, the database will default to the one in your profiles.yml file.
 - `<schema>` is the schema that will be used for the source. If not specified, the source name is assumed to be the schema which matches dbt's default behavior.
 
 #### Examples

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -275,7 +275,6 @@ class DbtYamlManager(DbtProject):
         config for the model / directory
         """
         osmosis_path_spec = self.get_osmosis_path_spec(node)
-        logger().info(osmosis_path_spec)
         if not osmosis_path_spec:
             # If no config is set, it is a no-op essentially
             return as_path(self.config.project_root, node.original_file_path)

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -271,6 +271,7 @@ class DbtYamlManager(DbtProject):
         config for the model / directory
         """
         osmosis_path_spec = self.get_osmosis_path_spec(node)
+        logger().info(osmosis_path_spec)
         if not osmosis_path_spec:
             # If no config is set, it is a no-op essentially
             return as_path(self.config.project_root, node.original_file_path)
@@ -443,6 +444,7 @@ class DbtYamlManager(DbtProject):
                             "sources": [
                                 {
                                     "name": source,
+                                    "database": database,
                                     "schema": schema,
                                     "tables": tables,
                                 }

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -237,7 +237,11 @@ class DbtYamlManager(DbtProject):
         """
         if node.resource_type == NodeType.Source:
             source_specs = self.config.vars.vars.get("dbt-osmosis", {})
-            return source_specs.get(node.source_name)
+            source_spec = source_specs.get(node.source_name)
+            if isinstance(source_spec, dict):
+                return source_spec.get("path")
+            else:
+                return source_spec
         osmosis_spec = node.unrendered_config.get("dbt-osmosis")
         if not osmosis_spec:
             raise MissingOsmosisConfig(

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -390,6 +390,7 @@ class DbtYamlManager(DbtProject):
                 path = spec
             elif isinstance(spec, dict):
                 schema = spec.get("schema", source)
+                database = spec.get("database", self.config.credentials.database)
                 path = spec["path"]
             else:
                 raise TypeError(
@@ -407,7 +408,7 @@ class DbtYamlManager(DbtProject):
                     self.config.model_paths[0], path.lstrip(os.sep)
                 )
                 relations = self.adapter.list_relations(
-                    database=self.config.credentials.database,
+                    database=database,
                     schema=schema,
                 )
                 tables = [


### PR DESCRIPTION
## Issues

1. For multi-database warehouses (like snowflake) it's important to be able to specify which database a set of sources resides in as well as a schema.
2. Right now the `yaml refactor` command fails when source config vars are dictionaries instead of just a path:
```yml
vars:
  dbt-osmosis:
    <source_name>: <path>  # Works
    <source_name>:  # Causes failures
      path: <path>
      schema: <schema>
```

## Solutions

### For issue (1):
1. Parse a database from the source spec, still defaulting to the configured default database from the dbt profile.
2. Write the database to generated source yml files explicitly.
3. Update documentation.

### For issue (2)

Add conditional logic to handle source specs that are dictionaries.