### PR TITLE
Add identifier property support for source entity type.

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -287,6 +287,8 @@ class DbtYamlManager(DbtProject):
     @staticmethod
     def get_catalog_key(node: ManifestNode) -> CatalogKey:
         """Returns CatalogKey for a given node."""
+        if node.resource_type == NodeType.Source:
+            return CatalogKey(node.database, node.schema, getattr(node, "identifier", node.name))
         return CatalogKey(node.database, node.schema, getattr(node, "alias", node.name))
 
     def get_base_model(self, node: ManifestNode) -> Dict[str, Any]:


### PR DESCRIPTION
Issue description:
- When running `refactor` on sources, in case if source name is not the same as identifier - we should use identifier, if available. 