### PR TITLE
[Fix] Process sources only when source yaml is available

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -677,10 +677,10 @@ class DbtYamlManager(DbtProject):
                     target_schema = {"version": 2}
                 elif "version" not in target_schema:
                     target_schema["version"] = 2
-                # Add models and sources to target schema
+                # Add models and sources (if available) to target schema
                 if structure.output["models"]:
                     target_schema.setdefault("models", []).extend(structure.output["models"])
-                if structure.output["sources"]:
+                if structure.output.get("sources") is not None:
                     target_schema.setdefault("sources", []).extend(structure.output["sources"])
                 if not self.dry_run:
                     self.yaml_handler.dump(target_schema, target)


### PR DESCRIPTION
**Issue description:**
When running `refactor`, process any changes to source yaml only when it exists/is defined. It is quite common for intermediate and mart models to not have a source file defined.

**How to reproduce**
Run `refactor` on a folder that contains schema yaml file but doesn't contain the source yaml file

**Additional context**
Should fix #115 