### PR TITLE
Fix edge case errors when forgetting to register model name in schema.yml.

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -253,8 +253,11 @@ class DbtYamlManager(DbtProject):
     def get_schema_path(self, node: ManifestNode) -> Optional[Path]:
         """Resolve absolute schema file path for a manifest node"""
         schema_path = None
-        if node.resource_type == NodeType.Model and node.patch_path:
-            schema_path: str = node.patch_path.partition("://")[-1]
+        if node.resource_type == NodeType.Model:
+            if node.patch_path:
+                schema_path: str = node.patch_path.partition("://")[-1]
+            else:
+                schema_path: str = node.original_file_path
         elif node.resource_type == NodeType.Source:
             if hasattr(node, "source_name"):
                 schema_path: str = node.path

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -591,9 +591,9 @@ class DbtYamlManager(DbtProject):
                     break
             for k in blueprint:
                 # Remove if sources or models are empty
-                if blueprint[k].output.get("sources", None) == []:
+                if blueprint[k].output.get("sources", []) == []:
                     del blueprint[k].output["sources"]
-                if blueprint[k].output.get("models", None) == []:
+                if blueprint[k].output.get("models", []) == []:
                     del blueprint[k].output["models"]
 
         except Exception as e:
@@ -681,9 +681,9 @@ class DbtYamlManager(DbtProject):
                 elif "version" not in target_schema:
                     target_schema["version"] = 2
                 # Add models and sources to target schema
-                if structure.output["models"]:
+                if structure.output.get("models"):
                     target_schema.setdefault("models", []).extend(structure.output["models"])
-                if structure.output["sources"]:
+                if structure.output.get("sources"):
                     target_schema.setdefault("sources", []).extend(structure.output["sources"])
                 if not self.dry_run:
                     self.yaml_handler.dump(target_schema, target)


### PR DESCRIPTION
Hi!

I found the edge case bug.

When model sql file exists in models folder without model name does not register in schema.yml, `dbt-osmosis yaml refactor` is failed.

The error messages I have encountered are as follows:

```
Traceback (most recent call last):
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/bin/dbt-osmosis", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/dbt_osmosis/main.py", line 80, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/dbt_osmosis/main.py", line 216, in refactor
    if runner.commit_project_restructure_to_disk():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/s23467/Library/Caches/pypoetry/virtualenvs/aoc-akagi-cdp-dbt-Pv9R6Ian-py3.11/lib/python3.11/site-packages/dbt_osmosis/core/osmosis.py", line 692, in commit_project_restructure_to_disk
    if structure.output["sources"]:
       ~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'sources'
```