### PR TITLE
Get the data_type and comment of child column instead of its parent

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -396,9 +396,9 @@ class DbtYamlManager(DbtProject):
                                     continue
                                 columns[self.column_casing(exp.name)] = ColumnMetadata(
                                     name=self.column_casing(exp.name),
-                                    type=c.dtype,
+                                    type=exp.dtype,
                                     index=None,
-                                    comment=getattr(c, "comment", None),
+                                    comment=getattr(exp, "comment", None),
                                 )
                 except Exception as error:
                     logger().info(


### PR DESCRIPTION
Currently, `dbt-osmosis` uses the data_type and comment of the parent column for all of its children. This PR fix that.