### PR TITLE
Fix pre-commit error by removing trailing whitespace

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -631,7 +631,7 @@ class DbtYamlManager(DbtProject):
                     futs.append(self.tpe.submit(self._draft, schema_file, unique_id, blueprint))
             wait(futs)
         return blueprint
-      
+
     def cleanup_blueprint(self, blueprint: dict) -> None:
         with self.mutex:
             for k in list(blueprint.keys()):
@@ -661,7 +661,7 @@ class DbtYamlManager(DbtProject):
         # Build blueprint if not user supplied
         if not blueprint:
             blueprint = self.draft_project_structure_update_plan()
-            
+
         blueprint = self.cleanup_blueprint(blueprint)
 
         # Verify we have actions in the plan


### PR DESCRIPTION
CI has failed since the merge of https://github.com/z3z1ma/dbt-osmosis/pull/131.

- https://github.com/z3z1ma/dbt-osmosis/actions/runs/8043780107/job/22102412580

The error was related to `trailing-whitespace` and has been fixed.