### PR TITLE
Initialize the variable `n_cols_added`

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -1059,6 +1059,7 @@ class DbtYamlManager(DbtProject):
     ) -> Tuple[int, int, int, int]:
         """Take action on a schema file mirroring changes in the node."""
         logger().info(":microscope: Looking for actions for %s", node.unique_id)
+        n_cols_added = 0
         if not self.skip_add_columns:
             n_cols_added = self.add_missing_cols_to_node_and_model(
                 missing_columns, node, section, columns_db_meta


### PR DESCRIPTION
fixes https://github.com/z3z1ma/dbt-osmosis/issues/135. FYI @b-per @z3z1ma 

I fixed `n_cols_added` was not initialized when the `--skip-add-columns` option was specified.