### PR TITLE
nit: Remove duplication setting for hadolint-docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,3 @@ repos:
 #    rev: 4.0.1
 #    hooks:
 #      - id: flake8
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
-    hooks:
-      - id: hadolint-docker


### PR DESCRIPTION
Since the `.pre-commit-config.yaml` contained two `hadolint/hadolint` configurations, we removed the duplicates.