### PR TITLE
nit: Update actions/checkout and actions/setup-python

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v4.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.10"
       - name: Install pre-commit hooks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
I've updated `actions/checkout` and `actions/setup-python` to the latest versions. Because both are actions that use Node.js 16 and [GitHub has recommended](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) that we move to actions that use Node.js 20.

- https://github.com/z3z1ma/dbt-osmosis/actions/runs/8542607513

![スクリーンショット 2024-04-04 2 13 11](https://github.com/z3z1ma/dbt-osmosis/assets/18356/a5675d9a-bc16-46f4-ae87-12cdcdefb9fc)

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

By the way, it is hard for humans to update the versions of libraries and actions, so it might be a good idea to introduce renovate and dependabot for dbt-osmosis as well :)