### PR TITLE
Fix `skip_add_data_types` condition in `update_columns_data_type`

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -1001,7 +1001,7 @@ class DbtYamlManager(DbtProject):
         columns_db_meta: Dict[str, ColumnMetadata],
     ) -> int:
         changes_committed = 0
-        if not self.skip_add_data_types:
+        if self.skip_add_data_types:
             return changes_committed
         for column in columns_db_meta:
             cased_column_name = self.column_casing(column)


### PR DESCRIPTION
@z3z1ma After updating dbt-osmosis to [version 0.12.8](https://github.com/z3z1ma/dbt-osmosis/blob/main/CHANGELOG.md#0128---2024-03-29), I noticed that the `data_type` attribute disappears from within the yaml. After reading the source code, I noticed that the `skip_add_data_types` condition in the `update_columns_data_type` function is wrong, so I will fix it.

- ref: https://github.com/z3z1ma/dbt-osmosis/commit/7756a80c0f449946c6d31584d51babe6f0802292