### PR TITLE
[feature] add inheritance for specified keys

### DIFF
--- a/src/dbt_osmosis/core/column_level_knowledge_propagator.py
+++ b/src/dbt_osmosis/core/column_level_knowledge_propagator.py
@@ -133,7 +133,6 @@ class ColumnLevelKnowledgePropagator:
         placeholders: List[str],
         project_dir: Path = Path.cwd(),
         use_unrendered_descriptions: bool = False,
-        add_inheritance_for_specified_keys: List[str] = [],
     ) -> Knowledge:
         """Build a knowledgebase for the model based on iterating through ancestors"""
         family_tree = _build_node_ancestor_tree(manifest, node)

--- a/src/dbt_osmosis/core/column_level_knowledge_propagator.py
+++ b/src/dbt_osmosis/core/column_level_knowledge_propagator.py
@@ -133,6 +133,7 @@ class ColumnLevelKnowledgePropagator:
         placeholders: List[str],
         project_dir: Path = Path.cwd(),
         use_unrendered_descriptions: bool = False,
+        add_inheritance_for_specified_keys: List[str] = [],
     ) -> Knowledge:
         """Build a knowledgebase for the model based on iterating through ancestors"""
         family_tree = _build_node_ancestor_tree(manifest, node)
@@ -194,6 +195,7 @@ class ColumnLevelKnowledgePropagator:
         skip_add_tags: bool,
         skip_merge_meta: bool,
         add_progenitor_to_meta: bool,
+        add_inheritance_for_specified_keys: Iterable[str] = [],
     ) -> int:
         """Update undocumented columns with prior knowledge in node and model simultaneously
         THIS MUTATES THE NODE AND MODEL OBJECTS so that state is always accurate"""
@@ -202,6 +204,9 @@ class ColumnLevelKnowledgePropagator:
             inheritables.append("tags")
         if not skip_merge_meta:
             inheritables.append("meta")
+        for key in add_inheritance_for_specified_keys:
+            if key not in inheritables:
+                inheritables.append(key)
 
         changes_committed = 0
         for column in undocumented_columns:

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -109,6 +109,7 @@ class DbtYamlManager(DbtProject):
         vars: Optional[str] = None,
         use_unrendered_descriptions: bool = False,
         profile: Optional[str] = None,
+        add_inheritance_for_specified_keys: Optional[List[str]] = None,
     ):
         """Initializes the DbtYamlManager class."""
         super().__init__(target, profiles_dir, project_dir, threads, vars=vars, profile=profile)
@@ -123,6 +124,7 @@ class DbtYamlManager(DbtProject):
         self.skip_merge_meta = skip_merge_meta
         self.add_progenitor_to_meta = add_progenitor_to_meta
         self.use_unrendered_descriptions = use_unrendered_descriptions
+        self.add_inheritance_for_specified_keys = add_inheritance_for_specified_keys or []
 
         if len(list(self.filtered_models())) == 0:
             logger().warning(
@@ -1081,6 +1083,7 @@ class DbtYamlManager(DbtProject):
                 self.skip_add_tags,
                 self.skip_merge_meta,
                 self.add_progenitor_to_meta,
+                self.add_inheritance_for_specified_keys,
             )
         )
         n_cols_data_type_updated = self.update_columns_data_type(node, section, columns_db_meta)

--- a/src/dbt_osmosis/main.py
+++ b/src/dbt_osmosis/main.py
@@ -177,6 +177,14 @@ def shared_opts(func: Callable) -> Callable:
         "This is useful for propogating docs blocks"
     ),
 )
+@click.option(
+    "--add-inheritance-for-specified-keys",
+    multiple=True,
+    type=click.STRING,
+    help=(
+        "If specified, will add inheritance for the specified keys."
+    )
+)
 @click.argument("models", nargs=-1)
 def refactor(
     target: Optional[str] = None,
@@ -196,6 +204,7 @@ def refactor(
     profile: Optional[str] = None,
     vars: Optional[str] = None,
     use_unrendered_descriptions: bool = False,
+    add_inheritance_for_specified_keys: Optional[List[str]] = None,
 ):
     """Executes organize which syncs yaml files with database schema and organizes the dbt models
     directory, reparses the project, then executes document passing down inheritable documentation
@@ -227,6 +236,7 @@ def refactor(
         profile=profile,
         vars=vars,
         use_unrendered_descriptions=use_unrendered_descriptions,
+        add_inheritance_for_specified_keys=add_inheritance_for_specified_keys,
     )
 
     # Conform project structure & bootstrap undocumented models injecting columns
@@ -307,6 +317,14 @@ def refactor(
         " my_value}'"
     ),
 )
+@click.option(
+    "--add-inheritance-for-specified-keys",
+    multiple=True,
+    type=click.STRING,
+    help=(
+        "If specified, will add inheritance for the specified keys."
+    )
+)
 @click.argument("models", nargs=-1)
 def organize(
     target: Optional[str] = None,
@@ -323,6 +341,7 @@ def organize(
     add_progenitor_to_meta: bool = False,
     profile: Optional[str] = None,
     vars: Optional[str] = None,
+    add_inheritance_for_specified_keys: Optional[List[str]] = None,
 ):
     """Organizes schema ymls based on config and injects undocumented models
 
@@ -351,6 +370,7 @@ def organize(
         add_progenitor_to_meta=add_progenitor_to_meta,
         profile=profile,
         vars=vars,
+        add_inheritance_for_specified_keys=add_inheritance_for_specified_keys,
     )
 
     # Conform project structure & bootstrap undocumented models injecting columns
@@ -454,6 +474,14 @@ def organize(
         "This is useful for propogating docs blocks"
     ),
 )
+@click.option(
+    "--add-inheritance-for-specified-keys",
+    multiple=True,
+    type=click.STRING,
+    help=(
+        "If specified, will add inheritance for the specified keys."
+    )
+)
 @click.argument("models", nargs=-1)
 def document(
     target: Optional[str] = None,
@@ -473,6 +501,7 @@ def document(
     profile: Optional[str] = None,
     vars: Optional[str] = None,
     use_unrendered_descriptions: bool = False,
+    add_inheritance_for_specified_keys: Optional[List[str]] = None,
 ):
     """Column level documentation inheritance for existing models
 
@@ -503,6 +532,7 @@ def document(
         profile=profile,
         vars=vars,
         use_unrendered_descriptions=use_unrendered_descriptions,
+        add_inheritance_for_specified_keys=add_inheritance_for_specified_keys,
     )
 
     # Propagate documentation & inject/remove schema file columns to align with model in database


### PR DESCRIPTION
I utilize BigQuery's column-level access control by setting policy_tags in numerous model.yml and source.yml files within dbt.
It would be beneficial if I could inherit policy_tags.
To this end, I have introduced a feature that allows not only the inheritance of policy_tags but also specified keys.