### PR TITLE
Modify to test with multiple versions of dbt-core

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,11 @@ jobs:
   tests:
     name: Run pytest
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        dbt-version: ["1.6.0", "1.7.0"]
+
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4.1.1
@@ -26,6 +31,10 @@ jobs:
         run: |
           pip install --constraint=.github/workflows/constraints.txt poetry
           poetry --version
+
+      - name: Install dbt-core
+        run: |
+          poetry add dbt-core==${{ matrix.dbt-version }}
 
       - name: Install required packages
         run: | # install duckdb extras to be able to parse manifest


### PR DESCRIPTION
dbt-osmosis currently supports working with various dbt-cores (we are assuming [1.3 or higher](https://github.com/z3z1ma/dbt-osmosis/blob/a1c21093c06713fb5f5486a3e3257c7ac5153857/src/dbt_osmosis/vendored/dbt_core_interface/project.py#L97-L137), I believe).

However, I think it is possible that dbt-osmosis will not work in the future if there is a change in the spec from a particular dbt-core version, as in https://github.com/z3z1ma/dbt-osmosis/issues/139. We have already received a pull request at https://github.com/z3z1ma/dbt-osmosis/pull/149 to support the change to dbt 1.8. We would like to ensure through CI that this change will not break existing behavior even if dbt is up to version 1.7.

Therefore, I have made a modification to make sure that CI will work with multiple dbt-core versions.