### PR TITLE
Modify to support dbt-core 1.6 and above

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/z3z1ma/dbt-osmosis"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.9.7 || >3.9.7,<3.12"
 click = ">7"
-dbt-core = ">=1"
+dbt-core = ">=1.6,<1.9"
 "ruamel.yaml" = ">=0.17"
 rich = ">=10"
 GitPython = ">3,<4"


### PR DESCRIPTION
Currently, dbt-osmosis supports a very wide range of dbt-core versions. As a result, there is code that diverges depending on the version of dbt-core, resulting in complexity and test case omissions. And `Support level and end date` for dbt 1.5 and below is `End of Life`.

- ref: https://docs.getdbt.com/docs/dbt-versions/core

This pull request explicitly limits the supported dbt-core versions so that dbt-osmosis can keep up with new dbt-core versions as they become available and remain highly maintainable.

- ref: https://github.com/z3z1ma/dbt-osmosis/pull/150/files#r1600410662