### PR TITLE
Fix: set ENV VARS as invocation context for dbt >= 1.8

### DIFF
--- a/src/dbt_osmosis/vendored/dbt_core_interface/project.py
+++ b/src/dbt_osmosis/vendored/dbt_core_interface/project.py
@@ -87,7 +87,8 @@ from dbt.adapters.factory import get_adapter_class_by_name
 
 try:
     # dbt >= 1.8
-    from dbt_common.clients.system import make_directory
+    from dbt_common.clients.system import make_directory, get_env
+    from dbt_common.context import set_invocation_context
 except ImportError:
     # dbt < 1.8
     from dbt.clients.system import make_directory
@@ -386,6 +387,8 @@ class DbtProject:
             project_dir=project_dir or DEFAULT_PROJECT_DIR,
             profile=profile,
         )
+        if hasattr(sys.modules[__name__], 'set_invocation_context'):
+            set_invocation_context(get_env())
         if vars is None:
             vars = "{}"
         self.base_config.vars = vars

--- a/src/dbt_osmosis/vendored/dbt_core_interface/project.py
+++ b/src/dbt_osmosis/vendored/dbt_core_interface/project.py
@@ -87,11 +87,12 @@ from dbt.adapters.factory import get_adapter_class_by_name
 
 try:
     # dbt >= 1.8
-    from dbt_common.clients.system import make_directory, get_env
+    from dbt_common.clients.system import get_env, make_directory
     from dbt_common.context import set_invocation_context
 except ImportError:
     # dbt < 1.8
     from dbt.clients.system import make_directory
+
 from dbt.config.runtime import RuntimeConfig
 from dbt.contracts.graph.nodes import ColumnInfo, ManifestNode
 from dbt.flags import set_from_args
@@ -387,7 +388,7 @@ class DbtProject:
             project_dir=project_dir or DEFAULT_PROJECT_DIR,
             profile=profile,
         )
-        if hasattr(sys.modules[__name__], 'set_invocation_context'):
+        if hasattr(sys.modules[__name__], "set_invocation_context"):
             set_invocation_context(get_env())
         if vars is None:
             vars = "{}"


### PR DESCRIPTION
### Rationale:
`dbt_core v1.8.0` introduces dependency on `dbt_common` package which wasn't the thing prior to 1.8.x.
In `dbt_common`, they introduce [`InvocationContext` class](https://github.com/dbt-labs/dbt-common/pull/52/files).
It's used in cli's `preflight` decorator that sets the context before any actual CLI operation:
- [set_invocation_context](https://github.com/dbt-labs/dbt-core/blob/v1.8.0/core/dbt/cli/requires.py#L58)
- [get_invocation_context](https://github.com/dbt-labs/dbt-core/blob/v1.8.0/core/dbt/cli/requires.py#L65)

Then it's used in `dbt_core`'s [`SecretContext`](https://github.com/dbt-labs/dbt-core/blob/v1.8.0/core/dbt/context/secret.py#L32) which is necessary if you use something like:
![CleanShot 2024-06-17 at 20 28 54@2x](https://github.com/z3z1ma/dbt-osmosis/assets/76563191/41883611-6a5a-4164-9e19-d2d7d271adf6)

### Changes:
This PR tries to import `set_invocation_context` and `get_env` from `dbt_common` and then set ENV VARs before actual profile rendering in Jinja.