### PR TITLE
Overwrite description when --catalog-file is specified

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -908,13 +908,13 @@ class DbtYamlManager(DbtProject):
                     return
 
                 should_dump = False
-                n_cols_added, n_cols_doc_inherited, n_cols_removed, n_cols_data_type_changed, n_cols_description_changed = (
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                )
+                (
+                    n_cols_added,
+                    n_cols_doc_inherited,
+                    n_cols_removed,
+                    n_cols_data_type_changed,
+                    n_cols_description_changed,
+                ) = (0, 0, 0, 0, 0)
                 if len(missing_columns) > 0 or len(undocumented_columns) or len(extra_columns) > 0:
                     # Update schema file
                     (
@@ -922,7 +922,7 @@ class DbtYamlManager(DbtProject):
                         n_cols_doc_inherited,
                         n_cols_removed,
                         n_cols_data_type_changed,
-                        n_cols_description_changed
+                        n_cols_description_changed,
                     ) = self.update_schema_file_and_node(
                         missing_columns,
                         undocumented_columns,
@@ -932,7 +932,11 @@ class DbtYamlManager(DbtProject):
                         columns_db_meta,
                     )
                 if (
-                    n_cols_added + n_cols_doc_inherited + n_cols_removed + n_cols_data_type_changed + n_cols_description_changed
+                    n_cols_added
+                    + n_cols_doc_inherited
+                    + n_cols_removed
+                    + n_cols_data_type_changed
+                    + n_cols_description_changed
                     > 0
                 ):
                     should_dump = True
@@ -1036,7 +1040,7 @@ class DbtYamlManager(DbtProject):
         columns_db_meta: Dict[str, ColumnMetadata],
         attribute_name: str,
         meta_key: str,
-        skip_attribute_update: Any
+        skip_attribute_update: Any,
     ) -> int:
         changes_committed = 0
         if (skip_attribute_update is True) or (skip_attribute_update is None):
@@ -1046,10 +1050,10 @@ class DbtYamlManager(DbtProject):
             if cased_column_name in node.columns:
                 column_meta_obj = columns_db_meta.get(cased_column_name)
                 if column_meta_obj:
-                    column_meta = getattr(column_meta_obj, meta_key, '')
+                    column_meta = getattr(column_meta_obj, meta_key, "")
                     if column_meta is None:
-                        column_meta = ''
-                    current_value = getattr(node.columns[cased_column_name], attribute_name, '')
+                        column_meta = ""
+                    current_value = getattr(node.columns[cased_column_name], attribute_name, "")
                     if current_value == column_meta:
                         continue
                     setattr(node.columns[cased_column_name], attribute_name, column_meta)
@@ -1127,23 +1131,19 @@ class DbtYamlManager(DbtProject):
             )
         )
         n_cols_data_type_updated = self.update_columns_attribute(
-            node,
-            section,
-            columns_db_meta,
-            "data_type",
-            "type",
-            self.skip_add_data_types
+            node, section, columns_db_meta, "data_type", "type", self.skip_add_data_types
         )
         n_cols_description_updated = self.update_columns_attribute(
-            node,
-            section,
-            columns_db_meta,
-            "description",
-            "comment",
-            self.catalog_file
+            node, section, columns_db_meta, "description", "comment", self.catalog_file
         )
         n_cols_removed = self.remove_columns_not_in_database(extra_columns, node, section)
-        return n_cols_added, n_cols_doc_inherited, n_cols_removed, n_cols_data_type_updated, n_cols_description_updated
+        return (
+            n_cols_added,
+            n_cols_doc_inherited,
+            n_cols_removed,
+            n_cols_data_type_updated,
+            n_cols_description_updated,
+        )
 
     @staticmethod
     def maybe_get_section_from_schema_file(


### PR DESCRIPTION
Hello! I am using your library for my work and have a feature request, so I've submitted a pull request. I would be grateful if you could take a look.

## Goal of This PR

- Ensures that when specifying a `--catalog-file` argument with `catalog.json`, the descriptions in the model's YAML file are populated from `catalog.json`.


## Current Behavior

- When using the --catalog-file argument with `catalog.json`, descriptions from `catalog.json `are only populated in the model’s YAML file if it already exists and lacks a column key.

If the model’s YAML file does not exist, the descriptions from `catalog.json` are **not populated**.

## What this PR Enables

- When specifying the `--catalog-file` argument, if the model’s YAML file does not exist and is newly created, descriptions from `catalog.json` will be populated.


![when create](https://github.com/user-attachments/assets/9b8ed755-548e-4538-b848-c918b4dbc3f8)


- When using the `--catalog-file` argument, descriptions in the model's YAML file are overwritten based on the content in `catalog.json`.

![overwrite](https://github.com/user-attachments/assets/3bcf71cc-ae09-4b14-a18a-8c7c914f0b2a)
