### PR TITLE
Add support for inheriting metadata through dbt-loom configured cross project dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 __pycache__/
 *.py[cod]
 *$py.class
-.vscode/
 # C extensions
 *.so
 
@@ -110,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.vscode
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.vscode
 # C extensions
 *.so
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-.vscode
+.vscode/
 # C extensions
 *.so
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "python.formatting.provider": "black",
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}


### PR DESCRIPTION
Adding support for injecting metadata from other manifests as defined in dbt-loom so that Inherit Upstream Column Knowledge can retrieve data from other projects.

If dbt-loom is installed, dbt-loom gets used to pull the relevant manifests as defined there.
Then the model nodes that are visible are injected into the manifest.

The Inherit Upstream Column Knowledge portion is modified to allow the f() function to search primarily through fqn to find these nodes, as they are from a different project, and that is okay here.

The code works, it retrieves column level metadata from one project to another.
But it should be rewritten to better conform to the overall logic and to be better.