### PR TITLE
fix python version check for typing import

### DIFF
--- a/src/dbt_osmosis/cli/main.py
+++ b/src/dbt_osmosis/cli/main.py
@@ -30,7 +30,7 @@ from dbt_osmosis.core.osmosis import (
 )
 
 T = t.TypeVar("T")
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 10):
     P = t.ParamSpec("P")
 else:
     import typing_extensions as te

--- a/src/dbt_osmosis/cli/main.py
+++ b/src/dbt_osmosis/cli/main.py
@@ -1,4 +1,7 @@
 # pyright: reportUnreachable=false, reportAny=false
+
+from __future__ import annotations
+
 import functools
 import io
 import subprocess

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -1096,7 +1096,7 @@ def _get_yaml_path_template(context: YamlRefactorContext, node: ResultNode) -> s
         for k in ("dbt-osmosis", "dbt_osmosis")
         for c in (node.config.extra, node.unrendered_config)
     ]
-    path_template = _find_first(t.cast(list[str | None], conf), lambda v: v is not None)
+    path_template = _find_first(t.cast(list[t.Union[str, None]], conf), lambda v: v is not None)
     if not path_template:
         raise MissingOsmosisConfig(
             f"Config key `dbt-osmosis: <path>` not set for model {node.name}"


### PR DESCRIPTION
Running dbt-osmosis on python 3.9 results in the following error : 
`AttributeError: module 'typing' has no attribute 'ParamSpec'`

Also switching to typing.Union in osmosis.py, it was throwing : 
```
python3.9/site-packages/dbt_osmosis/core/osmosis.py", line 1096, in _get_yaml_path_template
    path_template = _find_first(t.cast(list[str | None], conf), lambda v: v is not None)
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

I tested the refactor command and it works fine after those modifications