### PR TITLE
fix FileNotFoundError with external packages

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -665,9 +665,9 @@ def _is_fqn_match(node: ResultNode, fqns: list[str]) -> bool:
 def _is_file_match(node: ResultNode, paths: list[Path | str], root: Path | str) -> bool:
     """Check if a node's file path matches any of the provided file paths or names."""
     node_path = Path(root, node.original_file_path).resolve()
-    yaml_path = None
     if node.patch_path:
-        yaml_path = Path(root, node.patch_path.partition("://")[-1]).resolve()
+        absolute_patch_path = Path(root, node.patch_path.partition("://")[-1]).resolve()
+    yaml_path = absolute_patch_path if absolute_patch_path.exists() else None
     for model_or_dir in paths:
         model_or_dir = Path(model_or_dir).resolve()
         if node.name == model_or_dir.stem:


### PR DESCRIPTION
In _is_file_match(), the condition model_or_dir.samefile(yaml_path) raises an issue FileNotFoundError with yamlPath.

This is a simple check to ensure the yaml file exists.

How to reproduce : 
Have seeds from external packages such as [dbt_project_evaluator_exceptions.csv](https://dbt-labs.github.io/dbt-project-evaluator/latest/customization/exceptions/#1-create-a-new-seed). 
Patch path will be dbt_project_evaluator://seeds/seeds.yml even though it does not exist in the project.