### PR TITLE
fix: quoted boolean-like string must be dumped with quotes

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -368,6 +368,9 @@ def create_yaml_instance(
     y.encoding = encoding
 
     def str_representer(dumper: ruamel.yaml.RoundTripDumper, data: str) -> t.Any:
+        # https://github.com/commx/ruamel-yaml/blob/280677cf647912c599d8886000020d6ffbbb4216/resolver.py#L32
+        if re.match(r"^(y|Y|yes|Yes|YES|n|N|no|No|NO|on|On|ON|off|Off|OFF)$", data):
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style='"')
         newlines = len(data.splitlines())
         if newlines == 1 and len(data) > width - len(f"description{y.prefix_colon}: "):
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=">")


### PR DESCRIPTION
In dbt-osmosis, the ruamel-yaml library being used treats strings that look like Booleans as strings rather than as Booleans.

* https://github.com/commx/ruamel-yaml/blob/280677cf647912c599d8886000020d6ffbbb4216/_doc/detail.ryd#L178
* https://github.com/commx/ruamel-yaml/blob/280677cf647912c599d8886000020d6ffbbb4216/resolver.py#L26-L35

On the other hand, dbt is implemented under the assumption that strings resembling Booleans are treated as Booleans, and if one wishes to treat them as strings, quoting is required.

* https://github.com/dbt-labs/dbt-core/blob/9d7820c356e6bbdd8af756df1fc1b1a2c086b857/tests/unit/clients/test_jinja.py#L285-L295

In the current implementation of dbt-osmosis, strings that resemble Booleans are output as strings without quotes. As a result, when the output from dbt-osmosis is loaded as a dbt artifact, strings that are meant to be treated as strings end up being interpreted as Booleans. Consequently, if dbt-osmosis is executed twice on such strings, they eventually converge to Boolean values.

This Pull Request includes a fix that causes dbt-osmosis to quote strings that, although not handled as Booleans by dbt-osmosis, are interpreted as Booleans by dbt.

The following is a method to reproduce the issue where, in the current implementation of dbt-osmosis, strings that are not Booleans converge to Boolean values.

---
# Prepare Environment

## Add dbt model files with boolean-like string

```
$ cat <<EOF > demo_duckdb/models/jaffle_shop/main/sample_boolean_like.yml
---
version: 2
models:
  - name: sample_boolean_like
    columns:
      - name: order_id
        data_type: INTEGER
        meta:
          boolean_like: "Yes"

EOF

$ cat <<EOF > demo_duckdb/models/sample_boolean_like.sql
{{ config(
    alias="a_sample",
) }}

with final as (

    select order_id from {{ ref('stg_orders') }}

)

select * from final

EOF
```

## Build the deme_duckdb project

```
$ uv run dbt build --project-dir demo_duckdb --profiles-dir demo_duckdb
09:09:03  Running with dbt=1.9.1
09:09:04  Registered adapter: duckdb=1.9.1
09:09:04  Found 8 models, 3 seeds, 22 data tests, 424 macros
09:09:04  
09:09:04  Concurrency: 4 threads (target='dev')
09:09:04  
09:09:06  1 of 33 START seed file main.raw_customers ..................................... [RUN]
09:09:06  2 of 33 START seed file main.raw_orders ........................................ [RUN]
09:09:06  3 of 33 START seed file main.raw_payments ...................................... [RUN]
09:09:06  3 of 33 OK loaded seed file main.raw_payments .................................. [INSERT 113 in 0.09s]
09:09:06  2 of 33 OK loaded seed file main.raw_orders .................................... [INSERT 99 in 0.09s]
09:09:06  4 of 33 START sql view model main.stg_payments ................................. [RUN]
09:09:06  5 of 33 START sql view model main.stg_orders ................................... [RUN]
09:09:06  1 of 33 OK loaded seed file main.raw_customers ................................. [INSERT 100 in 0.10s]
09:09:06  6 of 33 START sql view model main.stg_customers ................................ [RUN]
09:09:06  7 of 33 START sql view model main.stg_customers_v2 ............................. [RUN]
09:09:06  7 of 33 OK created sql view model main.stg_customers_v2 ........................ [OK in 0.06s]
09:09:06  5 of 33 OK created sql view model main.stg_orders .............................. [OK in 0.07s]
09:09:06  4 of 33 OK created sql view model main.stg_payments ............................ [OK in 0.08s]
09:09:06  8 of 33 START test not_null_stg_customers_v2_id ................................ [RUN]
09:09:06  9 of 33 START test unique_stg_customers_v2_id .................................. [RUN]
09:09:06  10 of 33 START test accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned  [RUN]
09:09:06  6 of 33 OK created sql view model main.stg_customers ........................... [OK in 0.08s]
09:09:06  11 of 33 START test not_null_stg_orders_order_id ............................... [RUN]
09:09:06  8 of 33 PASS not_null_stg_customers_v2_id ...................................... [PASS in 0.04s]
09:09:06  9 of 33 PASS unique_stg_customers_v2_id ........................................ [PASS in 0.04s]
09:09:06  12 of 33 START test unique_stg_orders_order_id ................................. [RUN]
09:09:06  13 of 33 START test accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card  [RUN]
09:09:06  11 of 33 PASS not_null_stg_orders_order_id ..................................... [PASS in 0.02s]
09:09:06  10 of 33 PASS accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned  [PASS in 0.05s]
09:09:06  14 of 33 START test not_null_stg_payments_payment_id ........................... [RUN]
09:09:06  15 of 33 START test unique_stg_payments_payment_id ............................. [RUN]
09:09:06  12 of 33 PASS unique_stg_orders_order_id ....................................... [PASS in 0.04s]
09:09:06  14 of 33 PASS not_null_stg_payments_payment_id ................................. [PASS in 0.02s]
09:09:06  13 of 33 PASS accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card  [PASS in 0.03s]
09:09:06  16 of 33 START test not_null_stg_customers_v1_customer_id ...................... [RUN]
09:09:06  17 of 33 START test unique_stg_customers_v1_customer_id ........................ [RUN]
09:09:06  18 of 33 START sql table model main.a_sample ................................... [RUN]
09:09:06  15 of 33 PASS unique_stg_payments_payment_id ................................... [PASS in 0.03s]
09:09:06  19 of 33 START sql table model main.orders ..................................... [RUN]
09:09:06  16 of 33 PASS not_null_stg_customers_v1_customer_id ............................ [PASS in 0.04s]
09:09:06  17 of 33 PASS unique_stg_customers_v1_customer_id .............................. [PASS in 0.04s]
09:09:06  20 of 33 START sql table model main.orders_prefix .............................. [RUN]
09:09:06  21 of 33 START sql table model main.customers .................................. [RUN]
09:09:06  18 of 33 OK created sql table model main.a_sample .............................. [OK in 0.05s]
09:09:06  19 of 33 OK created sql table model main.orders ................................ [OK in 0.05s]
09:09:06  22 of 33 START test accepted_values_orders_status__placed__shipped__completed__return_pending__returned  [RUN]
09:09:06  23 of 33 START test not_null_orders_amount ..................................... [RUN]
09:09:06  20 of 33 OK created sql table model main.orders_prefix ......................... [OK in 0.05s]
09:09:06  24 of 33 START test not_null_orders_bank_transfer_amount ....................... [RUN]
09:09:06  21 of 33 OK created sql table model main.customers ............................. [OK in 0.06s]
09:09:06  25 of 33 START test not_null_orders_coupon_amount .............................. [RUN]
09:09:06  23 of 33 PASS not_null_orders_amount ........................................... [PASS in 0.04s]
09:09:06  22 of 33 PASS accepted_values_orders_status__placed__shipped__completed__return_pending__returned  [PASS in 0.04s]
09:09:06  24 of 33 PASS not_null_orders_bank_transfer_amount ............................. [PASS in 0.03s]
09:09:06  26 of 33 START test not_null_orders_credit_card_amount ......................... [RUN]
09:09:06  27 of 33 START test not_null_orders_customer_id ................................ [RUN]
09:09:06  28 of 33 START test not_null_orders_gift_card_amount ........................... [RUN]
09:09:06  25 of 33 PASS not_null_orders_coupon_amount .................................... [PASS in 0.03s]
09:09:06  29 of 33 START test not_null_orders_order_id ................................... [RUN]
09:09:06  27 of 33 PASS not_null_orders_customer_id ...................................... [PASS in 0.03s]
09:09:06  26 of 33 PASS not_null_orders_credit_card_amount ............................... [PASS in 0.03s]
09:09:06  30 of 33 START test unique_orders_order_id ..................................... [RUN]
09:09:06  28 of 33 PASS not_null_orders_gift_card_amount ................................. [PASS in 0.03s]
09:09:06  31 of 33 START test not_null_customers_customer_id ............................. [RUN]
09:09:06  32 of 33 START test relationships_orders_customer_id__customer_id__ref_customers_  [RUN]
09:09:06  29 of 33 PASS not_null_orders_order_id ......................................... [PASS in 0.03s]
09:09:06  33 of 33 START test unique_customers_customer_id ............................... [RUN]
09:09:06  31 of 33 PASS not_null_customers_customer_id ................................... [PASS in 0.03s]
09:09:06  30 of 33 PASS unique_orders_order_id ........................................... [PASS in 0.04s]
09:09:06  33 of 33 PASS unique_customers_customer_id ..................................... [PASS in 0.02s]
09:09:06  32 of 33 PASS relationships_orders_customer_id__customer_id__ref_customers_ .... [PASS in 0.04s]
09:09:06  
09:09:06  Finished running 3 seeds, 4 table models, 22 data tests, 4 view models in 0 hours 0 minutes and 1.51 seconds (1.51s).
09:09:06  
09:09:06  Completed successfully
09:09:06  
09:09:06  Done. PASS=33 WARN=0 ERROR=0 SKIP=0 TOTAL=33
```

# Before this Pull Request

## `"Yes"` becomes `Yes` in the first run.

```
$ uv run dbt-osmosis yaml refactor --project-dir ./demo_duckdb --profiles-dir ./demo_duckdb
INFO     🌊 Executing dbt-osmosis                                                                                                                 main.py:246
                                                                                                                                                             
INFO     👋 Creating DBT project context using config => DbtConfiguration(project_dir='./demo_duckdb', profiles_dir='./demo_duckdb',           osmosis.py:290
         target=None, profile=None, threads=None, single_threaded=None, vars={}, quiet=True, disable_introspection=False)                                    
INFO     📑 Registering adapter as part of project context creation.                                                                           osmosis.py:295
09:11:00  Registered adapter: duckdb=1.9.1
INFO     🔄 Loaded the dbt project manifest!                                                                                                   osmosis.py:316
<...snip...>
INFO     🏁 YAML commits completed in => 0.04s                                                                                                osmosis.py:1965

$ cat demo_duckdb/models/jaffle_shop/main/sample_boolean_like.yml                          
---
version: 2
models:
  - name: sample_boolean_like
    columns:
      - name: order_id
        data_type: INTEGER
        meta:
          boolean_like: Yes
```

## `Yes` becomes `true` in the second run

```
$ uv run dbt-osmosis yaml refactor --project-dir ./demo_duckdb --profiles-dir ./demo_duckdb
INFO     🌊 Executing dbt-osmosis                                                                                                                 main.py:246
                                                                                                                                                             
INFO     👋 Creating DBT project context using config => DbtConfiguration(project_dir='./demo_duckdb', profiles_dir='./demo_duckdb',           osmosis.py:290
         target=None, profile=None, threads=None, single_threaded=None, vars={}, quiet=True, disable_introspection=False)                                    
INFO     📑 Registering adapter as part of project context creation.                                                                           osmosis.py:295
09:11:00  Registered adapter: duckdb=1.9.1
INFO     🔄 Loaded the dbt project manifest!                                                                                                   osmosis.py:316
<...snip...>
INFO     🏁 YAML commits completed in => 0.04s                                                                                                osmosis.py:1965

$ cat demo_duckdb/models/jaffle_shop/main/sample_boolean_like.yml                          
---
version: 2
models:
  - name: sample_boolean_like
    columns:
      - name: order_id
        data_type: INTEGER
        meta:
          boolean_like: true
```

# After this Pull Request

## `"Yes"` is not changed

```
$ cat <<EOF > demo_duckdb/models/jaffle_shop/main/sample_boolean_like.yml
---
version: 2
models:
  - name: sample_boolean_like
    columns:
      - name: order_id
        data_type: INTEGER
        meta:
          boolean_like: "Yes"

EOF

$ uv run dbt-osmosis yaml refactor --project-dir ./demo_duckdb --profiles-dir ./demo_duckdb
INFO     🌊 Executing dbt-osmosis                                                                                                                 main.py:246
                                                                                                                                                             
INFO     👋 Creating DBT project context using config => DbtConfiguration(project_dir='./demo_duckdb', profiles_dir='./demo_duckdb',           osmosis.py:290
         target=None, profile=None, threads=None, single_threaded=None, vars={}, quiet=True, disable_introspection=False)                                    
INFO     📑 Registering adapter as part of project context creation.                                                                           osmosis.py:295
09:11:00  Registered adapter: duckdb=1.9.1
INFO     🔄 Loaded the dbt project manifest!                                                                                                   osmosis.py:316
<...snip...>
INFO     🏁 YAML commits completed in => 0.04s                                                                                                osmosis.py:1965

$ cat demo_duckdb/models/jaffle_shop/main/sample_boolean_like.yml         
---
version: 2
models:
  - name: sample_boolean_like
    columns:
      - name: order_id
        data_type: INTEGER
        meta:
          boolean_like: "Yes"
```

## `Yes` becomes `true` (the same behavior as before this Pull Request)

```
$ cat <<EOF > demo_duckdb/models/jaffle_shop/main/sample_boolean_like.yml                  
---
version: 2
models:
  - name: sample_boolean_like
    columns:
      - name: order_id
        data_type: INTEGER
        meta:
          boolean_like: Yes  

EOF

$ uv run dbt-osmosis yaml refactor --project-dir ./demo_duckdb --profiles-dir ./demo_duckdb
INFO     🌊 Executing dbt-osmosis                                                                                                                 main.py:246
                                                                                                                                                             
INFO     👋 Creating DBT project context using config => DbtConfiguration(project_dir='./demo_duckdb', profiles_dir='./demo_duckdb',           osmosis.py:290
         target=None, profile=None, threads=None, single_threaded=None, vars={}, quiet=True, disable_introspection=False)                                    
INFO     📑 Registering adapter as part of project context creation.                                                                           osmosis.py:295
09:11:00  Registered adapter: duckdb=1.9.1
INFO     🔄 Loaded the dbt project manifest!                                                                                                   osmosis.py:316
<...snip...>
INFO     🏁 YAML commits completed in => 0.04s                                                                                                osmosis.py:1965

$ cat demo_duckdb/models/jaffle_shop/main/sample_boolean_like.yml 
---
version: 2
models:
  - name: sample_boolean_like
    columns:
      - name: order_id
        data_type: INTEGER
        meta:
          boolean_like: true
```