### PR TITLE
Fix: UnboundLocalError: cannot access local variable 'absolute_patch_path' where it is not associated with a value

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -701,9 +701,11 @@ def _is_fqn_match(node: ResultNode, fqns: list[str]) -> bool:
 def _is_file_match(node: ResultNode, paths: list[Path | str], root: Path | str) -> bool:
     """Check if a node's file path matches any of the provided file paths or names."""
     node_path = Path(root, node.original_file_path).resolve()
+    yaml_path = None
     if node.patch_path:
         absolute_patch_path = Path(root, node.patch_path.partition("://")[-1]).resolve()
-    yaml_path = absolute_patch_path if absolute_patch_path.exists() else None
+        if absolute_patch_path.exists():
+            yaml_path = absolute_patch_path
     for model_or_dir in paths:
         model_or_dir = Path(model_or_dir).resolve()
         if node.name == model_or_dir.stem:


### PR DESCRIPTION
follow up https://github.com/z3z1ma/dbt-osmosis/pull/211

This PR fixes the error:

```
  File "/home/runner/work/test-repo/test-repo/.venv/lib/python3.11/site-packages/dbt_osmosis/core/osmosis.py", line 709, in _is_file_match
    yaml_path = absolute_patch_path if absolute_patch_path.exists() else None
                                       ^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'absolute_patch_path' where it is not associated with a value
```

The bug was caused by referencing the absolute_patch_path variable before it was assigned. The fix ensures that the variable is properly initialized before use.