### PR TITLE
fix: Respect output-to-lower option for name of sources

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -1085,7 +1085,7 @@ def create_missing_source_yamls(context: YamlRefactorContext) -> None:
 
         def _describe(rel: BaseRelation) -> dict[str, t.Any]:
             s = {
-                "name": rel.identifier,
+                "name": rel.identifier.lower() if lowercase else rel.identifier,
                 "description": "",
                 "columns": [
                     {


### PR DESCRIPTION
In data warehouses like Snowflake, where all identifiers are automatically converted to uppercase unless special handling is applied, running dbt-osmosis with the `--output-to-lower` option previously resulted in only the source name remaining in uppercase when creating missing sources. This pull request changes the behavior so that the `--output-to-lower` option is respected for the source name as well.

# Example: Running dbt-osmosis against the account_usage schema in Snowflake

```yaml
# dbt_project.yml
vars:
  dbt-osmosis:
    sources:
      snowflake__account_usage:
        path: "landing/snowflake/account_usage/sources.yml"
        database: snowflake
        schema: account_usage
```

## Before the Change

You can see that only the source name ACCESS_HISTORY is in uppercase.

```yaml
version: 2
sources:
  - name: snowflake__account_usage
    database: snowflake
    schema: account_usage
    tables:
      - name: ACCESS_HISTORY
        description: ''
        columns:
          - name: query_id
            description: ''
            data_type: varchar
          - name: query_start_time
            description: ''
            data_type: timestamp_ltz
          - name: user_name
            description: ''
            data_type: varchar
...<snip>...
```

## After the Change

```yaml
version: 2
sources:
  - name: snowflake__account_usage
    database: snowflake
    schema: account_usage
    tables:
      - name: access_history
        description: ''
        columns:
          - name: query_id
            description: ''
            data_type: varchar
          - name: query_start_time
            description: ''
            data_type: timestamp_ltz
          - name: user_name
            description: ''
            data_type: varchar
...<snip>...
```
