### PR TITLE
fix: Respect `numeric-precision-and-scale` and `string-length` options in node settings

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -884,8 +884,11 @@ def get_columns(
 
     result_node: ResultNode | None = None
     if not isinstance(relation, BaseRelation):
-        if isinstance(relation, ResultNode):
-            result_node = relation
+        # NOTE: Technically, we should use `isinstance(relation, ResultNode)` to verify it’s a ResultNode,
+        #       but since ResultNode is defined as a Union[...], Python 3.9 raises
+        #       > TypeError: Subscripted generics cannot be used with class and instance checks
+        #       To avoid that, we’re skipping the isinstance check.
+        result_node = relation  # may be a ResultNode
         relation = context.project.adapter.Relation.create_from(
             context.project.adapter.config,  # pyright: ignore[reportUnknownArgumentType]
             relation,  # pyright: ignore[reportArgumentType]

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -882,7 +882,10 @@ def get_columns(
         logger.debug(":blue_book: Relation is empty, skipping column collection.")
         return normalized_columns
 
+    result_node: ResultNode | None = None
     if not isinstance(relation, BaseRelation):
+        if isinstance(relation, ResultNode):
+            result_node = relation
         relation = context.project.adapter.Relation.create_from(
             context.project.adapter.config,  # pyright: ignore[reportUnknownArgumentType]
             relation,  # pyright: ignore[reportArgumentType]
@@ -913,7 +916,7 @@ def get_columns(
                 column.name, context.project.runtime_cfg.credentials.type
             )
             if not isinstance(column, ColumnMetadata):
-                dtype = _maybe_use_precise_dtype(column, context.settings)
+                dtype = _maybe_use_precise_dtype(column, context.settings, result_node)
                 column = ColumnMetadata(
                     name=normalized,
                     type=dtype,


### PR DESCRIPTION
Hi @z3z1ma,

In the current dbt-osmosis implementation, `_maybe_use_precise_dtype(...)` is called without a `ResultNode`. As a result, the `numeric-precision-and-scale` and `string-length` options always fall back to their defaults, so configurations like:

```
models:
  jaffle_shop_duckdb:
    +dbt-osmosis: "{node.database}/{node.schema}/{node.name}.yml"
    +dbt-osmosis-options:
      numeric-precision-and-scale: true
      string-length: true
```

are ignored.

To fix this, I updated the code so that if `get_columns(...)` is passed a `ResultNode`, it also forwards that `ResultNode` to `_maybe_use_precise_dtype(...)`.

---
### Check the behaviour

```
$ echo "${PWD/#$HOME/~}"
~/src/github.com/civitaspo/dbt-osmosis
$ vim ./demo_duckdb/dbt_project.yml
$ GIT_PAGER=cat git diff ./demo_duckdb/dbt_project.yml
diff --git a/demo_duckdb/dbt_project.yml b/demo_duckdb/dbt_project.yml
index ac72ade..dc2b0f6 100644
--- a/demo_duckdb/dbt_project.yml
+++ b/demo_duckdb/dbt_project.yml
@@ -22,6 +22,9 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 models:
   jaffle_shop_duckdb:
     +dbt-osmosis: "{node.database}/{node.schema}/{node.name}.yml"
+    +dbt-osmosis-options:
+      numeric-precision-and-scale: true
+      string-length: true
     materialized: table
     staging:
       materialized: view
$ uv run --all-extras dbt-osmosis yaml refactor --project-dir ./demo_duckdb --profiles-dir ./demo_duckdb
INFO     🌊 Executing dbt-osmosis 
...<snip>...
INFO     🏁 YAML commits completed in => 0.04s 
```

##### Before this PR

```
$ GIT_PAGER=cat git diff demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml 
diff --git a/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml b/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml
index 9d78bc8..1461c55 100644
--- a/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml
+++ b/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml
@@ -13,10 +13,13 @@ models:
               - unique
               - not_null
             data_type: INTEGER
+            description: ''
           - name: first_name
             data_type: VARCHAR
+            description: ''
           - name: last_name
             data_type: VARCHAR
+            description: ''
       - v: 2
         columns:
           - name: id
@@ -24,7 +27,10 @@ models:
               - unique
               - not_null
             data_type: INTEGER
+            description: ''
           - name: first_name
-            data_type: VARCHAR
+            data_type: character varying(256)
+            description: ''
           - name: last_name
-            data_type: VARCHAR
+            data_type: character varying(256)
+            description: ''
```

##### After this PR

```
$ GIT_PAGER=cat git diff demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml                  
diff --git a/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml b/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml
index 9d78bc8..983e0af 100644
--- a/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml
+++ b/demo_duckdb/models/staging/jaffle_shop/main/stg_customers.yml
@@ -13,10 +13,13 @@ models:
               - unique
               - not_null
             data_type: INTEGER
+            description: ''
           - name: first_name
-            data_type: VARCHAR
+            data_type: character varying(256)
+            description: ''
           - name: last_name
-            data_type: VARCHAR
+            data_type: character varying(256)
+            description: ''
       - v: 2
         columns:
           - name: id
@@ -24,7 +27,10 @@ models:
               - unique
               - not_null
             data_type: INTEGER
+            description: ''
           - name: first_name
-            data_type: VARCHAR
+            data_type: character varying(256)
+            description: ''
           - name: last_name
-            data_type: VARCHAR
+            data_type: character varying(256)
+            description: ''
```