### PR TITLE
fix: Use original node.columns keys to pop from node.columns when removing columns from schema files

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -2202,8 +2202,8 @@ def remove_columns_not_in_database(
             ...
         return
     current_columns = {
-        normalize_column_name(c.name, context.project.runtime_cfg.credentials.type)
-        for c in node.columns.values()
+        normalize_column_name(c.name, context.project.runtime_cfg.credentials.type): key
+        for key, c in node.columns.items()
     }
     incoming_columns = get_columns(context, node)
     if not incoming_columns:
@@ -2212,14 +2212,14 @@ def remove_columns_not_in_database(
             node.unique_id,
         )
         return
-    extra_columns = current_columns - set(incoming_columns.keys())
+    extra_columns = set(current_columns.keys()) - set(incoming_columns.keys())
     for extra_column in extra_columns:
         logger.info(
             ":heavy_minus_sign: Removing extra column => %s in node => %s",
             extra_column,
             node.unique_id,
         )
-        _ = node.columns.pop(extra_column, None)
+        _ = node.columns.pop(current_columns[extra_column], None)
 
 
 @_transform_op("Sort Columns in DB Order")


### PR DESCRIPTION
Hi @z3z1ma,

I’ve fixed a bug in this pull request that occurs when using Snowflake as the dbt adapter and running dbt-osmosis with the `--output-to-lower` option: even if you drop a column in Snowflake, dbt-osmosis doesn’t remove it from your schema file.

When Snowflake is used, dbt-osmosis uppercases column names via the `normalized_column_name()` method. However, if you specify `--output-to-lower`, the names in `node.columns` remain lowercase. As a result, in the original `remove_columns_not_in_database()` implementation, the final `node.columns.pop` step never matches anything, so dropped columns aren’t removed from the schema file.

I considered adding a reproducible case, but since this only happens with Snowflake, I hope the above explanation and the implementation changes are sufficient for your review.