### PR TITLE
feat: Add --use-specified-key-unrendered option for preserving Jinja in inherited keys

### DIFF
--- a/docs/docs/tutorial-basics/commands.md
+++ b/docs/docs/tutorial-basics/commands.md
@@ -50,6 +50,8 @@ Options often used:
 
 - `--force-inherit-descriptions` to override *existing* descriptions if they are placeholders
 - `--use-unrendered-descriptions` so that you can propagate Jinja-based docs (like `{{ doc(...) }}`)
+- `--add-inheritance-for-specified-keys` to inherit arbitrary keys (e.g., `policy_tags`) from upstream models. This can be specified multiple times.
+- `--use-specified-key-unrendered` to preserve Jinja templating within values inherited via `--add-inheritance-for-specified-keys`.
 - `--skip-add-columns`, `--skip-add-data-types`, `--skip-merge-meta`, `--skip-add-tags`, etc., if you want to limit changes
 - `--synthesize` to autogenerate missing documentation with ChatGPT/OpenAI (see *Synthesis* below)
 

--- a/src/dbt_osmosis/cli/main.py
+++ b/src/dbt_osmosis/cli/main.py
@@ -218,6 +218,11 @@ def yaml_opts(func: t.Callable[P, T]) -> t.Callable[P, T]:
     help="Add inheritance for the specified keys. IE policy_tags",
 )
 @click.option(
+    "--use-specified-key-unrendered",
+    is_flag=True,
+    help="Use unrendered specified keys in the documentation.",
+)
+@click.option(
     "--numeric-precision-and-scale",
     is_flag=True,
     help="Numeric types will have precision and scale, e.g. Number(38, 8).",
@@ -405,6 +410,11 @@ def organize(
     multiple=True,
     type=click.STRING,
     help="Add inheritance for the specified keys. IE policy_tags",
+)
+@click.option(
+    "--use-specified-key-unrendered",
+    is_flag=True,
+    help="Use unrendered specified keys in the documentation.",
 )
 @click.option(
     "--numeric-precision-and-scale",

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -454,6 +454,8 @@ class YamlRefactorSettings:
     """Force inheritance of descriptions from upstream models, even if node has a valid description."""
     use_unrendered_descriptions: bool = False
     """Use unrendered descriptions preserving things like {{ doc(...) }} which are otherwise pre-rendered in the manifest object"""
+    use_specified_key_unrendered: bool = False
+    """Use unrendered specified keys in the documentation."""
     add_inheritance_for_specified_keys: list[str] = field(default_factory=list)
     """Include additional keys in the inheritance process."""
     output_to_lower: bool = False
@@ -1930,6 +1932,14 @@ def _build_column_knowledge_graph(
                     current_val = graph_node.get(inheritable)
                     if incoming_unrendered_val := _get_unrendered(inheritable, ancestor):
                         graph_edge[inheritable] = incoming_unrendered_val
+                    elif _get_setting_for_node(
+                        "use-specified-key-unrendered",
+                        node,
+                        name,
+                        fallback=context.settings.use_specified_key_unrendered,
+                    ):
+                        if unrendered_val := _get_unrendered(inheritable, ancestor):
+                            graph_edge[inheritable] = unrendered_val
                     elif incoming_val := graph_edge.pop(inheritable, current_val):
                         graph_edge[inheritable] = incoming_val
 

--- a/tests/test_yaml_inheritance.py
+++ b/tests/test_yaml_inheritance.py
@@ -211,7 +211,7 @@ def test_build_node_ancestor_tree(node_id: str, expected_tree: dict[str, list[st
                 "policy_tags": ["pii_main"],
             },
         ),
-        # Case 7: Use unrendered  any specified keys
+        # Case 7: Use unrendered specified keys
         (
             {
                 "use_specified_key_unrendered": True,

--- a/tests/test_yaml_inheritance.py
+++ b/tests/test_yaml_inheritance.py
@@ -211,6 +211,28 @@ def test_build_node_ancestor_tree(node_id: str, expected_tree: dict[str, list[st
                 "policy_tags": ["pii_main"],
             },
         ),
+        # Case 7: Use unrendered  any specified keys
+        (
+            {
+                "use_specified_key_unrendered": True,
+                "add_inheritance_for_specified_keys": ["policy_tags"],
+                "force_inherit_descriptions": True,
+            },
+            {
+                "stg_customers.v1.customer_id": {
+                    "description": "I will prevail",
+                    "meta": {"a": 1},
+                    "tags": ["foo", "bar"],
+                    "_extra": {"policy_tags": ["{{ var('policy_tags') }}"]},
+                }
+            },
+            {
+                "description": "I will prevail",
+                "meta": {"a": 1, "c": 3},
+                "tags": ["foo", "bar", "baz"],
+                "policy_tags": ["{{ var('policy_tags') }}"],
+            },
+        ),
     ],
 )
 def test_inherit_upstream_column_knowledge_with_various_settings(


### PR DESCRIPTION
## Summary

This PR introduces a new command-line option, `--use-specified-key-unrendered`, to the YAML refactoring commands (`document` and `refactor`).

When this flag is active, and used in conjunction with inheriting custom keys (previously managed by `--add-inheritance-for-specified-keys`), the Jinja templating within the values of these inherited keys will be preserved as is, rather than being rendered. This is particularly useful when the inherited values contain dbt macros or `doc()` calls that should remain dynamic in the downstream models.

## Changes

-   **CLI (`src/dbt_osmosis/cli/main.py`):**
    -   Added the `--use-specified-key-unrendered` option to the `yaml_opts` decorator, making it available for `document` and `refactor` commands.
-   **Core Logic (`src/dbt_osmosis/core/osmosis.py`):**
    -   Updated `YamlRefactorSettings` to include `use_specified_key_unrendered`.
    -   The logic in `_build_column_knowledge_graph` now checks this setting to determine whether to use the unrendered value for specified inheritable keys.
-   **Documentation (`docs/docs/tutorial-basics/commands.md`):**
    -   Updated the `document` and `refactor` command sections to include and explain the new `--use-specified-key-unrendered` flag.

## Impact

This change provides users with finer control over how custom metadata is inherited, ensuring that Jinja templating can be maintained when propagating values through the dbt project structure. This is especially beneficial for complex documentation or metadata patterns that rely on dynamic rendering at the point of use.