### PR TITLE
Fix: include node.config.meta in YAML path template retrieval

### DIFF
--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -1146,7 +1146,7 @@ def _get_yaml_path_template(context: YamlRefactorContext, node: ResultNode) -> s
     conf = [
         c.get(k)
         for k in ("dbt-osmosis", "dbt_osmosis")
-        for c in (node.config.extra, node.unrendered_config)
+        for c in (node.config.extra, node.config.meta, node.unrendered_config)
     ]
     path_template = _find_first(t.cast("list[str | None]", conf), lambda v: v is not None)
     if not path_template:


### PR DESCRIPTION
Adding arbitrary keys to dbt schemas in models will be prohibited in the future. https://github.com/dbt-labs/dbt-core/discussions/11493

Instead, it seems necessary to define it as follows in `+meta`.

```yaml
models:
  my_dbt:
    +meta:
      dbt-osmosis: 'schema.yml'
    sandbox:
      database: CDP
      schema: SANDBOX
      tags: ['sandbox']
      materialized: view
```

This fix adds meta to the location where dbt-osmosis settings are retrieved.
