### PR TITLE
fix: delete `config` attribute if it exists

### DIFF
--- a/src/dbt_osmosis/core/transforms.py
+++ b/src/dbt_osmosis/core/transforms.py
@@ -280,6 +280,8 @@ def inject_missing_columns(context: t.Any, node: ResultNode | None = None) -> No
             ):
                 gen_col["data_type"] = dtype.lower() if context.settings.output_to_lower else dtype
             node.columns[incoming_name] = ColumnInfo.from_dict(gen_col)
+            if hasattr(node.columns[incoming_name], "config"):
+                delattr(node.columns[incoming_name], "config")
 
 
 @_transform_op("Remove Extra Columns")


### PR DESCRIPTION
Hi @z3z1ma ,

We encountered this issue when upgrading to `dbt-core>=1.9.6` (see triage I've done on the issue itself).

Closes https://github.com/z3z1ma/dbt-osmosis/issues/278

Still need to do more extended testing, and maybe there is a more idiomatic way of doing this. E.g. by adding a config flag to exclude certain fields on the [`ColumnInfo` class](https://github.com/dbt-labs/dbt-core/blob/19393a8080a7c238705326d0610867e9ea61fae6/core/dbt/artifacts/resources/v1/components.py#L80), because there might be a case where users actually want to include it in the generation.

The thing is that `ColumnInfo` is loaded in dynamically (if I understand the code correct) so the implementation of `ColumnInfo` can vary per dbt-core version which caused this issue in the first place.

Let me know if you would rather see a solution with something like an optional flag to make it more dynamic. This could look like `--skip-column-properties=config,some_orther_prop_to_skip`, then I will change this PR accordingly.