### PR TITLE
Fix: Support BigQuery column descriptions alongside other adapters

### DIFF
--- a/src/dbt_osmosis/core/introspection.py
+++ b/src/dbt_osmosis/core/introspection.py
@@ -207,11 +207,13 @@ def get_columns(
             )
             if not isinstance(column, ColumnMetadata):
                 dtype = _maybe_use_precise_dtype(column, context.settings, result_node)
+                # BigQuery uses "description" attribute, other adapters use "comment"
+                col_comment = getattr(column, "description", None) or getattr(column, "comment", None)
                 column = ColumnMetadata(
                     name=normalized,
                     type=dtype,
                     index=index,
-                    comment=getattr(column, "comment", None),
+                    comment=col_comment,
                 )
             normalized_columns[normalized] = column
             index += 1


### PR DESCRIPTION
 ### Problem

When introspecting database columns, dbt-osmosis was only checking for the `comment` attribute (used by Snowflake, Postgres, etc.) but  not the `description` attribute used by BigQuery's column objects.

This caused BigQuery column descriptions to be lost during column introspection, resulting in empty descriptions in generated YAML files even when columns had descriptions in BigQuery.

This is related to #120, since the linked dbt-core issue (https://github.com/dbt-labs/dbt-core/issues/9198) was closed as not planned.
Therefore, with BigQuery, the `comment` attribute is always empty since BigQuery uses `description` instead ([official 
docs](https://docs.cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.schema.SchemaField)).

### Solution

Updated `get_columns()` in `src/dbt_osmosis/core/introspection.py` to check for both attributes:

```python
col_comment = getattr(column, "description", None) or getattr(column, "comment", None)
```
This maintains compatibility with all adapters:
- BigQuery: Uses description from `google.cloud.bigquery.SchemaField`
- other adapters (Snowflake, Postgres, Redshift, etc.): Use comment from their respective column objects
- fallback: Returns None if neither attribute exists

WDYT? :) 