### PR TITLE
Fixes #294

### DIFF
--- a/src/dbt_osmosis/core/inheritance.py
+++ b/src/dbt_osmosis/core/inheritance.py
@@ -487,6 +487,15 @@ def _build_column_knowledge_graph(
     # This ensures local metadata is preserved and merged with inherited metadata
     column_knowledge_graph: dict[str, dict[str, t.Any]] = {}
     for name, column in node.columns.items():
+        # PATCH: Fix missing config attribute in dbt-core 1.11+ objects causing mashumaro serialization error
+        if not hasattr(column, 'config'):
+            try:
+                from dbt.artifacts.resources.v1.components import ColumnConfig
+                column.config = ColumnConfig()
+            except ImportError:
+                # Fallback if import fails, though it shouldn't for this dbt version
+                pass
+
         column_data = column.to_dict(omit_none=True)
 
         # Clear out osmosis_progenitor if it points to the target node itself


### PR DESCRIPTION
It patched the `dbt-osmosis` library code.
- Added a check to detect if the `config` attribute is missing on `ColumnInfo` objects.
- If missing, the patch injects a default `ColumnConfig` object before serialization takes place.
- This allows `mashumaro` to successfully serialize the object without crashing.
