### PR TITLE
make openai optional

### DIFF
--- a/src/dbt_osmosis/core/llm.py
+++ b/src/dbt_osmosis/core/llm.py
@@ -9,8 +9,15 @@ import typing as t
 from dataclasses import dataclass
 from textwrap import dedent
 
-import openai
-from openai import OpenAI
+try:
+    import openai
+    from openai import OpenAI
+
+    _OPENAI_AVAILABLE = True
+except ImportError:
+    openai = None  # type: ignore[assignment]
+    OpenAI = None  # type: ignore[assignment,misc]
+    _OPENAI_AVAILABLE = False
 
 from dbt_osmosis.core.exceptions import LLMConfigurationError, LLMResponseError
 
@@ -74,6 +81,12 @@ def get_llm_client():
         LLMConfigurationError: If required environment variables are missing or provider is invalid.
 
     """
+    if not _OPENAI_AVAILABLE:
+        raise ImportError(
+            "OpenAI is not installed. Please install it with: "
+            "pip install 'dbt-osmosis[openai]' or pip install openai"
+        )
+
     provider = os.getenv("LLM_PROVIDER", "openai").lower()
 
     if provider == "openai":

--- a/src/dbt_osmosis/core/osmosis.py
+++ b/src/dbt_osmosis/core/osmosis.py
@@ -1,4 +1,5 @@
 # pyright: reportUnknownVariableType=false, reportPrivateImportUsage=false, reportAny=false, reportUnknownMemberType=false
+# ruff: noqa: E402
 """dbt-osmosis core module with backwards compatibility imports."""
 
 from __future__ import annotations
@@ -39,11 +40,28 @@ from dbt_osmosis.core.introspection import (
     normalize_column_name,
 )
 
-# Natural language generation (from llm.py)
-from dbt_osmosis.core.llm import (
-    generate_dbt_model_from_nl,
-    generate_sql_from_nl,
-)
+# Natural language generation (from llm.py) - conditional on openai availability
+_llm_available = importlib.util.find_spec("openai") is not None
+
+if _llm_available:
+    from dbt_osmosis.core.llm import (
+        generate_dbt_model_from_nl,
+        generate_sql_from_nl,
+    )
+else:
+    # Stub functions that raise helpful errors
+    def generate_dbt_model_from_nl(*args, **kwargs):  # type: ignore[misc]
+        raise ImportError(
+            "Natural language features require OpenAI. "
+            "Install with: pip install 'dbt-osmosis[openai]'"
+        )
+
+    def generate_sql_from_nl(*args, **kwargs):  # type: ignore[misc]
+        raise ImportError(
+            "Natural language features require OpenAI. "
+            "Install with: pip install 'dbt-osmosis[openai]'"
+        )
+
 
 # Node filtering and sorting
 from dbt_osmosis.core.node_filters import (
@@ -100,28 +118,92 @@ from dbt_osmosis.core.sql_operations import (
     execute_sql_code,
 )
 
-# Staging operations
-from dbt_osmosis.core.staging import (
-    StagingGenerationResult,
-    generate_staging_for_all_sources,
-    generate_staging_for_source,
-    write_staging_files,
-)
+# Staging operations - conditional on openai availability
+if _llm_available:
+    from dbt_osmosis.core.staging import (
+        StagingGenerationResult,
+        generate_staging_for_all_sources,
+        generate_staging_for_source,
+        write_staging_files,
+    )
+else:
+    # Stub classes/functions
+    class StagingGenerationResult:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise ImportError(
+                "Staging generation requires OpenAI. "
+                "Install with: pip install 'dbt-osmosis[openai]'"
+            )
+
+    def generate_staging_for_all_sources(*args, **kwargs):  # type: ignore[misc]
+        raise ImportError(
+            "Staging generation requires OpenAI. Install with: pip install 'dbt-osmosis[openai]'"
+        )
+
+    def generate_staging_for_source(*args, **kwargs):  # type: ignore[misc]
+        raise ImportError(
+            "Staging generation requires OpenAI. Install with: pip install 'dbt-osmosis[openai]'"
+        )
+
+    def write_staging_files(*args, **kwargs):  # type: ignore[misc]
+        raise ImportError(
+            "Staging generation requires OpenAI. Install with: pip install 'dbt-osmosis[openai]'"
+        )
+
 
 # Sync operations
 from dbt_osmosis.core.sync_operations import (
     sync_node_to_yaml,
 )
 
-# Test suggestion operations
-from dbt_osmosis.core.test_suggestions import (
-    AITestSuggester,
-    ModelTestAnalysis,
-    TestPatternExtractor,
-    TestSuggestion,
-    suggest_tests_for_model,
-    suggest_tests_for_project,
-)
+# Test suggestion operations - conditional on openai availability
+if _llm_available:
+    from dbt_osmosis.core.test_suggestions import (
+        AITestSuggester,
+        ModelTestAnalysis,
+        TestPatternExtractor,
+        TestSuggestion,
+        suggest_tests_for_model,
+        suggest_tests_for_project,
+    )
+else:
+    # Stub classes/functions
+    class AITestSuggester:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise ImportError(
+                "AI test suggestions require OpenAI. "
+                "Install with: pip install 'dbt-osmosis[openai]'"
+            )
+
+    class ModelTestAnalysis:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise ImportError(
+                "AI test analysis requires OpenAI. Install with: pip install 'dbt-osmosis[openai]'"
+            )
+
+    class TestPatternExtractor:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise ImportError(
+                "Test pattern extraction requires OpenAI. "
+                "Install with: pip install 'dbt-osmosis[openai]'"
+            )
+
+    class TestSuggestion:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise ImportError(
+                "Test suggestions require OpenAI. Install with: pip install 'dbt-osmosis[openai]'"
+            )
+
+    def suggest_tests_for_model(*args, **kwargs):  # type: ignore[misc]
+        raise ImportError(
+            "AI test suggestions require OpenAI. Install with: pip install 'dbt-osmosis[openai]'"
+        )
+
+    def suggest_tests_for_project(*args, **kwargs):  # type: ignore[misc]
+        raise ImportError(
+            "AI test suggestions require OpenAI. Install with: pip install 'dbt-osmosis[openai]'"
+        )
+
 
 # Transform operations
 from dbt_osmosis.core.transforms import (
@@ -144,8 +226,6 @@ from dbt_osmosis.core.voice_learning import (
     extract_style_examples,
     find_similar_documented_nodes,
 )
-
-_llm_available = importlib.util.find_spec("openai") is not None
 
 # Note: process_node is imported in sql_operations.py where it's used
 


### PR DESCRIPTION
Fixes: #299

When running dbt-osmosis without the openai package installed the CLI fails immediately with:

```python
  ModuleNotFoundError: No module named 'openai'
    File "src/dbt_osmosis/core/llm.py", line 12, in <module>
      import openai
```

  This happens even for non-LLM commands like dbt-osmosis yaml refactor because the import chain loads llm.py at module initialization time, despite OpenAI being listed as an optional dependency in pyproject.toml and in docs.

WDYT? :) 