### PR TITLE
fix(transforms): apply case conversion to column keys in inject_missing_columns

### DIFF
--- a/src/dbt_osmosis/core/transforms.py
+++ b/src/dbt_osmosis/core/transforms.py
@@ -335,6 +335,13 @@ def inject_missing_columns(
         for c in node.columns.values()
     }
     incoming_columns = get_columns(context, node)
+    output_to_upper = _get_setting_for_node(
+        "output-to-upper", node, fallback=context.settings.output_to_upper
+    )
+    output_to_lower = _get_setting_for_node(
+        "output-to-lower", node, fallback=context.settings.output_to_lower
+    )
+
     for incoming_name, incoming_meta in incoming_columns.items():
         if incoming_name not in current_columns:
             logger.info(
@@ -342,7 +349,13 @@ def inject_missing_columns(
                 incoming_name,
                 node.unique_id,
             )
-            gen_col = {"name": incoming_name, "description": incoming_meta.comment or ""}
+            final_name = incoming_name
+            if output_to_upper:
+                final_name = incoming_name.upper()
+            elif output_to_lower:
+                final_name = incoming_name.lower()
+
+            gen_col = {"name": final_name, "description": incoming_meta.comment or ""}
             if (dtype := incoming_meta.type) and not _get_setting_for_node(
                 "skip-add-data-types",
                 node,
@@ -354,9 +367,9 @@ def inject_missing_columns(
                     gen_col["data_type"] = dtype.lower()
                 else:
                     gen_col["data_type"] = dtype
-            node.columns[incoming_name] = ColumnInfo.from_dict(gen_col)
-            if hasattr(node.columns[incoming_name], "config"):
-                delattr(node.columns[incoming_name], "config")
+            node.columns[final_name] = ColumnInfo.from_dict(gen_col)
+            if hasattr(node.columns[final_name], "config"):
+                delattr(node.columns[final_name], "config")
 
 
 @_transform_op("Remove Extra Columns")

--- a/tests/core/test_transforms.py
+++ b/tests/core/test_transforms.py
@@ -170,3 +170,114 @@ def test_sort_columns_alphabetically_without_case_conversion(
     assert column_names == ["Banana", "ZEBRA", "apple"], (
         f"Columns should be sorted by original name (ASCII order), got {column_names}"
     )
+
+
+def test_inject_missing_columns_applies_output_to_lower(fresh_caches):
+    """Test that inject_missing_columns converts new column keys to lowercase
+    when output-to-lower is enabled.
+
+    This fixes the issue where Snowflake returns uppercase column names,
+    which are injected as uppercase keys. Subsequent alphabetical sorting
+    uses lowercase comparison, but the keys remain uppercase, causing
+    incorrect sort order on the first run.
+    """
+    from collections import OrderedDict
+
+    mock_node = mock.MagicMock()
+    mock_node.unique_id = "model.test.test_model"
+    mock_node.resource_type = "model"
+    mock_node.columns = OrderedDict()
+
+    context = mock.MagicMock()
+    context.settings.skip_add_columns = False
+    context.settings.skip_add_source_columns = False
+    context.settings.skip_add_data_types = False
+    context.settings.output_to_lower = True
+    context.settings.output_to_upper = False
+    context.project.runtime_cfg.credentials.type = "snowflake"
+
+    # Simulate database returning uppercase column names (Snowflake behavior)
+    mock_col_a = mock.MagicMock()
+    mock_col_a.type = "VARCHAR"
+    mock_col_a.comment = ""
+    mock_col_b = mock.MagicMock()
+    mock_col_b.type = "INTEGER"
+    mock_col_b.comment = ""
+    mock_col_c = mock.MagicMock()
+    mock_col_c.type = "BOOLEAN"
+    mock_col_c.comment = ""
+
+    incoming = OrderedDict([("ZEBRA", mock_col_a), ("APPLE", mock_col_b), ("BANANA", mock_col_c)])
+
+    # Patch at dbt_osmosis.core.introspection (source module) because
+    # inject_missing_columns uses local imports (from ... import get_columns),
+    # which re-resolve the module attribute on each call.
+    with (
+        mock.patch(
+            "dbt_osmosis.core.introspection.get_columns",
+            return_value=incoming,
+        ),
+        mock.patch(
+            "dbt_osmosis.core.introspection._get_setting_for_node",
+            side_effect=lambda *args, fallback=None, **kw: fallback,
+        ),
+    ):
+        inject_missing_columns(context, mock_node)
+
+    # Keys should be lowercase
+    column_keys = list(mock_node.columns.keys())
+    assert all(k == k.lower() for k in column_keys), (
+        f"All column keys should be lowercase, got {column_keys}"
+    )
+    assert set(column_keys) == {"zebra", "apple", "banana"}
+
+
+def test_inject_missing_columns_with_lower_then_sort_alphabetically(fresh_caches):
+    """End-to-end test: inject with output-to-lower followed by alphabetical sort
+    should produce correctly ordered lowercase keys on the first run.
+    """
+    from collections import OrderedDict
+
+    mock_node = mock.MagicMock()
+    mock_node.unique_id = "model.test.test_model"
+    mock_node.resource_type = "model"
+    mock_node.columns = OrderedDict()
+
+    context = mock.MagicMock()
+    context.settings.skip_add_columns = False
+    context.settings.skip_add_source_columns = False
+    context.settings.skip_add_data_types = True
+    context.settings.output_to_lower = True
+    context.settings.output_to_upper = False
+    context.project.runtime_cfg.credentials.type = "snowflake"
+
+    mock_col = mock.MagicMock()
+    mock_col.type = None
+    mock_col.comment = ""
+
+    incoming = OrderedDict([
+        ("ZEBRA", mock_col),
+        ("APPLE", mock_col),
+        ("BANANA", mock_col),
+    ])
+
+    # Patch at source module; see comment in test_inject_missing_columns_applies_output_to_lower
+    with (
+        mock.patch(
+            "dbt_osmosis.core.introspection.get_columns",
+            return_value=incoming,
+        ),
+        mock.patch(
+            "dbt_osmosis.core.introspection._get_setting_for_node",
+            side_effect=lambda *args, fallback=None, **kw: fallback,
+        ),
+    ):
+        inject_missing_columns(context, mock_node)
+
+    # Now sort alphabetically
+    sort_columns_alphabetically(context, mock_node)
+
+    column_keys = list(mock_node.columns.keys())
+    assert column_keys == ["apple", "banana", "zebra"], (
+        f"Columns should be alphabetically sorted lowercase on first run, got {column_keys}"
+    )


### PR DESCRIPTION
## Summary

Fix incorrect alphabetical sort order on the first run when `output-to-lower` is enabled with Snowflake.

### Problem

When using `--output-to-lower` with `sort-by: alphabetical`, newly added columns were not sorted correctly on the first run (a second run was required). The root cause was that `inject_missing_columns()` used the normalized column name from the database (uppercase for Snowflake) as the dictionary key in `node.columns`. The subsequent `sort_columns_alphabetically()` compared by lowercase, but the keys themselves remained uppercase, resulting in incorrect ordering.

### Fix

Apply `output-to-lower` / `output-to-upper` case conversion to both the dictionary key and the column name at injection time in `inject_missing_columns()`, so that subsequent sorting produces the correct order from the first execution.

- Column name case conversion uses `_get_setting_for_node` (respects per-node settings, consistent with `sort_columns_alphabetically` and `sync_operations`)
- Data type case conversion remains using `context.settings` directly (unchanged from previous behavior)

### Tests

- `test_inject_missing_columns_applies_output_to_lower`: verifies uppercase DB columns are added with lowercase keys when `output_to_lower=True`
- `test_inject_missing_columns_with_lower_then_sort_alphabetically`: end-to-end test verifying inject + sort produces correct alphabetical order on first run

Closes #309