### PR TITLE
fix: normalize column-level meta to config.meta for dbt 1.9+

### DIFF
--- a/src/dbt_osmosis/core/sync_operations.py
+++ b/src/dbt_osmosis/core/sync_operations.py
@@ -171,27 +171,14 @@ def _sync_doc_section(
 
         if context.project.is_dbt_v1_10_or_greater:
             meta_value = merged.get("meta")
-            config_value = merged.get("config")
-            config_meta = config_value.get("meta") if isinstance(config_value, dict) else None
-            if isinstance(meta_value, dict) and isinstance(config_meta, dict):
-                merged["meta"] = {
-                    **t.cast("dict[str, t.Any]", config_meta),
-                    **t.cast("dict[str, t.Any]", meta_value),
-                }
-                config_dict = dict(t.cast("dict[str, t.Any]", config_value))
-                config_dict.pop("meta", None)
-                if config_dict:
-                    merged["config"] = config_dict
-                else:
-                    merged.pop("config", None)
-            elif isinstance(config_meta, dict) and not skip_merge_meta:
-                merged["meta"] = t.cast("dict[str, t.Any]", config_meta)
-                config_dict = dict(t.cast("dict[str, t.Any]", config_value))
-                config_dict.pop("meta", None)
-                if config_dict:
-                    merged["config"] = config_dict
-                else:
-                    merged.pop("config", None)
+            if isinstance(meta_value, dict) and meta_value:
+                # dbt 1.9+ recommends column-level meta under config.meta, not as a top-level property
+                # Top-level meta for columns is deprecated in dbt 1.9+
+                # See: https://docs.getdbt.com/reference/deprecations
+                if not isinstance(merged.get("config"), dict):
+                    merged["config"] = {}
+                merged["config"]["meta"] = meta_value
+                merged.pop("meta", None)
 
         if merged.get("description") is None:
             merged.pop("description", None)


### PR DESCRIPTION
Thanks for maintaining this project! I'd appreciate your review on this small fix.

## Problem

In dbt 1.9+, column-level `meta` should be stored under `config.meta` rather than as a top-level `meta` property (see [dbt deprecations](https://docs.getdbt.com/reference/deprecations)). The previous logic in
`_sync_doc_section` was doing the opposite — it was merging `config.meta` into the top-level `meta`, which perpetuated the deprecated pattern.

## Solution

When dbt v1.10+ is detected and a column has a top-level `meta` dict, normalize it by moving it into `config.meta` and removing the top-level `meta` key. This aligns the written YAML with dbt's recommended
structure going forward.

**Before:**
```yaml
columns:
  - name: user_id
    meta:
      pii: true
```

After:
```yaml
columns:
  - name: user_id
    config:
      meta:
        pii: true
```

The change also removes the now-unnecessary bidirectional merge logic, simplifying the code significantly.
