### PR TITLE
fix: case-insensitive Snowflake relation matching for catalog lookup in get_columns

### DIFF
--- a/src/dbt_osmosis/core/introspection.py
+++ b/src/dbt_osmosis/core/introspection.py
@@ -1154,16 +1154,27 @@ def get_columns(
 
     if catalog := context.read_catalog():
         logger.debug(":blue_book: Catalog found => Checking for ref => %s", rendered_relation)
-        matcher = getattr(relation_any, "matches", None)
-
-        def matches_relation(entry: t.Any) -> bool:
-            if not callable(matcher):
-                return False
-            return bool(matcher(*entry.key()))
-
+        
+        def matches_relation_case_insensitive(c: t.Any) -> bool:
+            #For Snowflake, use case-insensitive matching
+            if context.project.runtime_cfg.credentials.type == "snowflake": 
+                try:
+                    catalog_key = tuple(
+                        k.upper() if isinstance(k, str) else k for k in c.key()
+                    )
+                    relation_key = tuple(
+                        k.upper() if isinstance(k, str) else k 
+                        for k in (relation.database, relation.schema, relation.name)
+                    )
+                    return catalog_key == relation_key
+                except Exception:
+                    pass
+            # Default to case-ensitive matching:
+            return relation.matches(*c.key())
+        
         catalog_entry = _find_first(
             chain(catalog.nodes.values(), catalog.sources.values()),
-            matches_relation,
+            matches_relation_case_insensitive,
         )
         if catalog_entry:
             logger.info(


### PR DESCRIPTION
## Summary
Fixes Snowflake catalog lookup failures caused by case-sensitive relation matching in `get_columns()`.

## Problem
When `target/catalog.json` contains uppercase relation names (common in Snowflake), dbt-osmosis may look up the same relation in lowercase and thus fails to match it.

Example mismatch:
- searched: `db.schema.table_name`
- catalog: `db.schema.TABLE_NAME`

This prevents selecting the catalog entry and can lead to `ApproximateMatchError` / missing metadata behavior.

## Root Cause
Catalog matching used:
- `relation.matches(*c.key())`
which is case-sensitive for this Snowflake scenario.

## Change
In `src/dbt_osmosis/core/introspection.py` (`get_columns()`):
- Added Snowflake-specific case-insensitive catalog matching by normalizing both sides to uppercase before comparison.
- Kept existing behavior for non-Snowflake adapters.
- Added safe fallback to default matcher if normalization path fails.

## Validation
Validated locally with:
`dbt-osmosis yaml refactor TABLE_NAME --catalog-path target\catalog.json

Result: catalog entry is found correctly despite case differences.

## Related / Complementary
This PR is complementary to #322 .

- #322 addresses **column-level** case handling in transforms.
- This PR addresses **relation-level** case handling during **catalog lookup** in `get_columns()`.