### PR TITLE
chore: add release note for real-node path fix

### DIFF
--- a/.changes/unreleased/Fixed-20260409-120000.yaml
+++ b/.changes/unreleased/Fixed-20260409-120000.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: |-
+    Restore passing the real dbt node when rendering YAML path templates so node-derived expressions resolve correctly again.
+
+    - Fixes path templates that depend on real node attributes and metadata, including expressions like `{node.meta[competitor]}`.
+    - Follow-up release note for the merged path management fix in #340.
+time: 2026-04-09T12:00:00Z


### PR DESCRIPTION
This follow-up PR adds the release note for the already-merged path management fix in #340.

That fix is on `main`, but it is not part of the current published release line. This PR is intended to make the change visible in the next patch release so downstream users can consume it from PyPI instead of installing from GitHub.

Merged fix:
- #340
- commit 86c9f85 (`chore: switch back to passing real node in path management`)

Scope:
- add one Changie unreleased `Fixed` entry only
- no version bump
- no changelog regeneration