### PR TITLE
feat: add anchor-description column flag + treat whitespace descriptions as empty

### DIFF
--- a/src/dbt_osmosis/core/inheritance.py
+++ b/src/dbt_osmosis/core/inheritance.py
@@ -75,8 +75,11 @@ def _initialize_column_knowledge(column: t.Any, node: ResultNode) -> dict[str, t
             if not column_data["config"]:
                 column_data.pop("config", None)
 
-    # Match the existing graph-builder behavior by dropping empty scalars/collections.
-    return {k: v for k, v in column_data.items() if v not in ("", [], ())}
+    # Match the existing graph-builder behavior by dropping empty/whitespace-only strings and empty lists.
+    return {
+        k: v for k, v in column_data.items()
+        if not (isinstance(v, str) and not v.strip()) and v not in ([], ())
+    }
 
 
 def _strip_progenitor_override_controls(column_data: dict[str, t.Any]) -> None:
@@ -347,8 +350,8 @@ def _clean_graph_edge(
     ):
         graph_edge.pop("description", None)
 
-    # Remove empty descriptions (that weren't caught by placeholder check)
-    if graph_edge.get("description") == "":
+    # Remove empty/whitespace-only descriptions (that weren't caught by placeholder check)
+    if not graph_edge.get("description", "").strip():
         graph_edge.pop("description", None)
 
     # Remove empty tags and meta objects

--- a/src/dbt_osmosis/core/schema/parser.py
+++ b/src/dbt_osmosis/core/schema/parser.py
@@ -108,6 +108,7 @@ def create_yaml_instance(
     y = OsmosisYAML()
     y.indent(mapping=indent_mapping, sequence=indent_sequence, offset=indent_offset)
     y.width = width
+    y.best_width = width
     y.preserve_quotes = preserve_quotes
     y.default_flow_style = default_flow_style
     y.encoding = encoding

--- a/src/dbt_osmosis/core/sync_operations.py
+++ b/src/dbt_osmosis/core/sync_operations.py
@@ -33,7 +33,7 @@ def _sync_doc_section(
     logger.debug(":arrows_counterclockwise: Syncing doc_section with node => %s", node.unique_id)
     if node.description and not doc_section.get("description"):
         if context.settings.scaffold_empty_configs or node.description not in context.placeholders:
-            doc_section["description"] = node.description
+            doc_section["description"] = str(node.description)
 
     current_columns: list[dict[str, t.Any]] = doc_section.setdefault("columns", [])
     incoming_columns: list[dict[str, t.Any]] = []
@@ -170,7 +170,7 @@ def _sync_doc_section(
             if k in preserved_yaml_fields:
                 # Preserve unrendered jinja templates from current YAML (prefer-yaml-values)
                 continue
-            merged[k] = v
+            merged[k] = str(v) if k == "description" and isinstance(v, str) else v
 
         if context.fusion_compat:
             # Fusion mode: push top-level meta/tags INTO config block

--- a/src/dbt_osmosis/core/transforms.py
+++ b/src/dbt_osmosis/core/transforms.py
@@ -269,16 +269,20 @@ def inherit_upstream_column_knowledge(
                     inheritable.append("meta")
 
         # Special case: if force_inherit_descriptions is False and the local column already has
-        # a description, don't inherit the description from upstream (preserve local description)
+        # a description, don't inherit the description from upstream (preserve local description).
+        # If anchor-description is set on a column, it is exempt from force-inherit-descriptions,
+        # preserving the manually curated description even during a forced re-propagation pass.
+        force_inherit = _get_setting_for_node(
+            "force-inherit-descriptions",
+            node,
+            name,
+            fallback=context.settings.force_inherit_descriptions,
+        )
+        is_anchored = bool(_get_setting_for_node("anchor-description", node, name, fallback=False))
         if (
             "description" in inheritable
-            and not _get_setting_for_node(
-                "force-inherit-descriptions",
-                node,
-                name,
-                fallback=context.settings.force_inherit_descriptions,
-            )
-            and node_column.description
+            and (not force_inherit or is_anchored)
+            and node_column.description.strip()
         ):
             inheritable.remove("description")
 


### PR DESCRIPTION
  ## Summary

  Two related fixes for description inheritance behaviour:

  ### 1. Whitespace-only descriptions treated as empty

  Descriptions containing only whitespace (e.g. `"   "`) were previously
  treated as non-empty content, causing them to:
  - block inheritance on the downstream node (falsy check passed `"   "` as truthy)
  - propagate silently through the DAG as blank noise

  **Fix:** strip before empty-checks in two places in `inheritance.py`:
  - `_clean_graph_edge` — upstream propagation edge filtering
  - `_build_column_knowledge_graph` — column initialization filter

  ### 2. `anchor-description` per-column meta flag

  When `--force-inherit-descriptions` is enabled globally, there is no way
  to exempt individual columns from being overwritten. This is a problem for
  manually curated descriptions (e.g. business definitions, domain-specific
  context) that should survive a full re-propagation pass.

  The new `anchor-description: true` column meta flag opts a column out of
  `--force-inherit-descriptions` while still allowing its description to
  propagate further downstream — acting as a reset point in the DAG.

  **Usage:**
  ```yaml
  columns:
    - name: id
      description: "Our internal ID — not the source system ID, see docs/ids.md"
      meta:
        anchor-description: true

  Behaviour matrix:

  ┌────────────────────┬───────────────┬──────────────────────────────┬────────────────────────────────────────┐
  │      Scenario      │    Default    │ --force-inherit-descriptions │    --force-inherit-descriptions +      │
  │                    │               │                              │        anchor-description: true        │
  ├────────────────────┼───────────────┼──────────────────────────────┼────────────────────────────────────────┤
  │ Column has no      │ filled from   │ filled from upstream         │ filled from upstream                   │
  │ description        │ upstream      │                              │                                        │
  ├────────────────────┼───────────────┼──────────────────────────────┼────────────────────────────────────────┤
  │ Column has         │ preserved     │ overwritten                  │ preserved ✓                            │
  │ description        │               │                              │                                        │
  ├────────────────────┼───────────────┼──────────────────────────────┼────────────────────────────────────────┤
  │ Downstream of      │ inherits      │ inherits anchor desc         │ inherits anchor desc                   │
  │ anchored column    │ anchor desc   │                              │                                        │
  └────────────────────┴───────────────┴──────────────────────────────┴────────────────────────────────────────┘

  Relation to deprecated osmosis_keep_description

  osmosis_keep_description was the v1.1.x opt-out from the old aggressive
  default. anchor-description serves the same purpose but specifically for
  the --force-inherit-descriptions opt-in mode introduced in v1.2.0.
  ```