### PR TITLE
fix: treat whitespace descriptions as empty and prevent YAML fold-point oscillation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling==1.26.3"]  # hatch-vcs
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [project]
 name = "dbt-osmosis"
 version = "1.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ requires-python = ">=3.10,<3.14"
 
 dependencies = [
   "click>7,<9",
+  "dbt-col-lineage @ git+https://github.com/Felix313/dbt-column-lineage.git",
   "dbt-core>=1.8",
   "dbt-core-interface>=1.1.7",
   "ruamel.yaml>=0.17,<0.19",

--- a/src/dbt_osmosis/cli/main.py
+++ b/src/dbt_osmosis/cli/main.py
@@ -34,6 +34,7 @@ from dbt_osmosis.core.sql_lint import SQLLinter, lint_sql_code
 from dbt_osmosis.core.sql_operations import compile_sql_code, execute_sql_code
 from dbt_osmosis.core.test_suggestions import suggest_tests_for_model, suggest_tests_for_project
 from dbt_osmosis.core.transforms import (
+    enrich_rename_descriptions,
     inherit_upstream_column_knowledge,
     inject_missing_columns,
     remove_columns_not_in_database,
@@ -390,6 +391,7 @@ def refactor(
             inject_missing_columns
             >> remove_columns_not_in_database
             >> inherit_upstream_column_knowledge
+            >> enrich_rename_descriptions
             >> sort_columns_as_configured
             >> synchronize_data_types
         )
@@ -587,6 +589,7 @@ def document(
         transform = (
             inject_missing_columns
             >> inherit_upstream_column_knowledge
+            >> enrich_rename_descriptions
             >> sort_columns_as_configured
         )
         if synthesize:

--- a/src/dbt_osmosis/core/inheritance.py
+++ b/src/dbt_osmosis/core/inheritance.py
@@ -75,8 +75,11 @@ def _initialize_column_knowledge(column: t.Any, node: ResultNode) -> dict[str, t
             if not column_data["config"]:
                 column_data.pop("config", None)
 
-    # Match the existing graph-builder behavior by dropping empty scalars/collections.
-    return {k: v for k, v in column_data.items() if v not in ("", [], ())}
+    # Match the existing graph-builder behavior by dropping empty/whitespace-only strings and empty lists.
+    return {
+        k: v for k, v in column_data.items()
+        if not (isinstance(v, str) and not v.strip()) and v not in ([], ())
+    }
 
 
 def _strip_progenitor_override_controls(column_data: dict[str, t.Any]) -> None:
@@ -347,8 +350,8 @@ def _clean_graph_edge(
     ):
         graph_edge.pop("description", None)
 
-    # Remove empty descriptions (that weren't caught by placeholder check)
-    if graph_edge.get("description") == "":
+    # Remove empty/whitespace-only descriptions (that weren't caught by placeholder check)
+    if not graph_edge.get("description", "").strip():
         graph_edge.pop("description", None)
 
     # Remove empty tags and meta objects

--- a/src/dbt_osmosis/core/schema/parser.py
+++ b/src/dbt_osmosis/core/schema/parser.py
@@ -108,6 +108,7 @@ def create_yaml_instance(
     y = OsmosisYAML()
     y.indent(mapping=indent_mapping, sequence=indent_sequence, offset=indent_offset)
     y.width = width
+    y.best_width = width
     y.preserve_quotes = preserve_quotes
     y.default_flow_style = default_flow_style
     y.encoding = encoding

--- a/src/dbt_osmosis/core/sync_operations.py
+++ b/src/dbt_osmosis/core/sync_operations.py
@@ -31,6 +31,8 @@ def _sync_doc_section(
     takes precedence over the manifest's data_type.
     """
     logger.debug(":arrows_counterclockwise: Syncing doc_section with node => %s", node.unique_id)
+    if "description" in doc_section and doc_section["description"] is not None:
+        doc_section["description"] = str(doc_section["description"])
     if node.description and not doc_section.get("description"):
         if context.settings.scaffold_empty_configs or node.description not in context.placeholders:
             doc_section["description"] = str(node.description)

--- a/src/dbt_osmosis/core/sync_operations.py
+++ b/src/dbt_osmosis/core/sync_operations.py
@@ -33,7 +33,7 @@ def _sync_doc_section(
     logger.debug(":arrows_counterclockwise: Syncing doc_section with node => %s", node.unique_id)
     if node.description and not doc_section.get("description"):
         if context.settings.scaffold_empty_configs or node.description not in context.placeholders:
-            doc_section["description"] = node.description
+            doc_section["description"] = str(node.description)
 
     current_columns: list[dict[str, t.Any]] = doc_section.setdefault("columns", [])
     incoming_columns: list[dict[str, t.Any]] = []
@@ -170,7 +170,7 @@ def _sync_doc_section(
             if k in preserved_yaml_fields:
                 # Preserve unrendered jinja templates from current YAML (prefer-yaml-values)
                 continue
-            merged[k] = v
+            merged[k] = str(v) if k == "description" and isinstance(v, str) else v
 
         if context.fusion_compat:
             # Fusion mode: push top-level meta/tags INTO config block

--- a/src/dbt_osmosis/core/transforms.py
+++ b/src/dbt_osmosis/core/transforms.py
@@ -269,16 +269,20 @@ def inherit_upstream_column_knowledge(
                     inheritable.append("meta")
 
         # Special case: if force_inherit_descriptions is False and the local column already has
-        # a description, don't inherit the description from upstream (preserve local description)
+        # a description, don't inherit the description from upstream (preserve local description).
+        # If anchor-description is set on a column, it is exempt from force-inherit-descriptions,
+        # preserving the manually curated description even during a forced re-propagation pass.
+        force_inherit = _get_setting_for_node(
+            "force-inherit-descriptions",
+            node,
+            name,
+            fallback=context.settings.force_inherit_descriptions,
+        )
+        is_anchored = bool(_get_setting_for_node("anchor-description", node, name, fallback=False))
         if (
             "description" in inheritable
-            and not _get_setting_for_node(
-                "force-inherit-descriptions",
-                node,
-                name,
-                fallback=context.settings.force_inherit_descriptions,
-            )
-            and node_column.description
+            and (not force_inherit or is_anchored)
+            and node_column.description.strip()
         ):
             inheritable.remove("description")
 

--- a/src/dbt_osmosis/core/transforms.py
+++ b/src/dbt_osmosis/core/transforms.py
@@ -269,19 +269,15 @@ def inherit_upstream_column_knowledge(
                     inheritable.append("meta")
 
         # Special case: if force_inherit_descriptions is False and the local column already has
-        # a description, don't inherit the description from upstream (preserve local description).
-        # If anchor-description is set on a column, it is exempt from force-inherit-descriptions,
-        # preserving the manually curated description even during a forced re-propagation pass.
-        force_inherit = _get_setting_for_node(
-            "force-inherit-descriptions",
-            node,
-            name,
-            fallback=context.settings.force_inherit_descriptions,
-        )
-        is_anchored = bool(_get_setting_for_node("anchor-description", node, name, fallback=False))
+        # a description, don't inherit the description from upstream (preserve local description)
         if (
             "description" in inheritable
-            and (not force_inherit or is_anchored)
+            and not _get_setting_for_node(
+                "force-inherit-descriptions",
+                node,
+                name,
+                fallback=context.settings.force_inherit_descriptions,
+            )
             and node_column.description.strip()
         ):
             inheritable.remove("description")

--- a/src/dbt_osmosis/core/transforms.py
+++ b/src/dbt_osmosis/core/transforms.py
@@ -22,6 +22,7 @@ __all__ = [
     "TransformOperation",
     "TransformPipeline",
     "_transform_op",
+    "enrich_rename_descriptions",
     "inherit_upstream_column_knowledge",
     "inject_missing_columns",
     "remove_columns_not_in_database",
@@ -592,6 +593,208 @@ def synchronize_data_types(
                     column.data_type = inc_c.type.lower()
                 else:
                     column.data_type = inc_c.type
+
+
+# Module-level cache for column lineage results keyed by (project_dir, model_name).
+# This prevents repeated dbt adapter calls when the transform is applied to many nodes
+# in a single run. The cache is intentionally process-scoped (no TTL) because a single
+# osmosis invocation operates against a single, stable manifest snapshot.
+_LINEAGE_CACHE: dict[tuple[str, str], list[t.Any]] = {}
+
+
+def _find_progenitor_description(
+    context: YamlRefactorContextProtocol,
+    progenitor_model: str | None,
+    progenitor_column: str | None,
+) -> str | None:
+    """Look up the description for a progenitor column in the in-memory manifest.
+
+    Args:
+        context: The YamlRefactorContext instance.
+        progenitor_model: The model name (not unique_id) of the progenitor.
+        progenitor_column: The column name in the progenitor model.
+
+    Returns:
+        The description string, or None if not found / empty / placeholder.
+    """
+    if not progenitor_model or not progenitor_column:
+        return None
+
+    col_lower = progenitor_column.lower()
+    for uid, upstream_node in context.project.manifest.nodes.items():
+        if getattr(upstream_node, "name", None) != progenitor_model:
+            continue
+        cols: dict[str, t.Any] = getattr(upstream_node, "columns", {})
+        # Case-insensitive column lookup (Snowflake uppercases column names)
+        col_info = cols.get(progenitor_column) or next(
+            (v for k, v in cols.items() if k.lower() == col_lower), None
+        )
+        if col_info is None:
+            return None
+        desc = getattr(col_info, "description", None) or ""
+        if desc and desc not in context.placeholders:
+            return desc
+        return None
+
+    return None
+
+
+@_transform_op("Enrich Renamed Column Descriptions")
+def enrich_rename_descriptions(
+    context: YamlRefactorContextProtocol,
+    node: ResultNode | None = None,
+) -> None:
+    """Enrich descriptions for columns that are SQL renames of upstream columns.
+
+    For each column that ``get_column_lineage`` identifies as a rename
+    (``is_rename=True``), this transform builds a description from:
+    - The ``rename-description-prefix`` template (default: ``"renamed from {source_col}"``)
+    - The upstream progenitor column description (if found in the manifest)
+
+    The enrichment is controlled by two per-node osmosis-options keys:
+
+    - ``rename-descriptions`` (bool, default False): must be True to activate.
+    - ``rename-description-prefix`` (str): prefix template; ``{source_col}``
+      is substituted with the original column name.
+
+    Interaction with ``force-inherit-descriptions``:
+    - If False and the column already has a non-placeholder description, the
+      column is left untouched.
+    - If True, the rename description is always applied.
+
+    Nodes without compiled SQL (sources, ephemeral) are silently skipped.
+    Any failure from ``get_column_lineage`` is logged as a warning and the
+    node is skipped gracefully.
+    """
+    from pathlib import Path as _Path
+
+    from dbt.artifacts.resources.types import NodeType
+    from dbt_osmosis.core.introspection import _get_setting_for_node
+    from dbt_osmosis.core.node_filters import _iter_candidate_nodes
+
+    if node is None:
+        logger.info(":wave: Enriching renamed column descriptions across all matched nodes.")
+        for _ in context.pool.map(
+            partial(enrich_rename_descriptions, context),
+            (n for _, n in _iter_candidate_nodes(context)),
+        ):
+            ...
+        return
+
+    # --- Guard: feature must be enabled for this node ---
+    rename_descriptions = _get_setting_for_node(
+        "rename-descriptions",
+        node,
+        fallback=False,
+    )
+    if not rename_descriptions:
+        logger.debug(
+            ":no_entry_sign: rename-descriptions disabled for => %s",
+            node.unique_id,
+        )
+        return
+
+    # --- Guard: sources and ephemeral models have no compiled SQL ---
+    if node.resource_type == NodeType.Source:
+        logger.debug(
+            ":no_entry_sign: Skipping rename enrichment for source => %s",
+            node.unique_id,
+        )
+        return
+    compiled_code = getattr(node, "compiled_code", None) or getattr(node, "compiled_sql", None)
+    if not compiled_code:
+        logger.debug(
+            ":no_entry_sign: No compiled SQL for => %s, skipping rename enrichment",
+            node.unique_id,
+        )
+        return
+
+    force_inherit = _get_setting_for_node(
+        "force-inherit-descriptions",
+        node,
+        fallback=context.settings.force_inherit_descriptions,
+    )
+    prefix_template: str = _get_setting_for_node(
+        "rename-description-prefix",
+        node,
+        fallback="renamed from {source_col}",
+    )
+
+    # --- Fetch lineage (with per-process caching) ---
+    project_dir: str = context.project.config.project_dir
+    manifest_path = str(_Path(project_dir) / "target" / "manifest.json")
+    profiles_dir: str = context.project.config.profiles_dir
+    target: str | None = context.project.config.target
+
+    cache_key = (project_dir, node.name)
+    if cache_key not in _LINEAGE_CACHE:
+        try:
+            from dbt_column_lineage.api import get_column_lineage
+
+            _LINEAGE_CACHE[cache_key] = get_column_lineage(
+                manifest_path=manifest_path,
+                live_db=True,
+                project_dir=project_dir,
+                profiles_dir=profiles_dir,
+                target=target,
+                models=[node.name],
+                compiled_sql_source="target_dir",
+            )
+        except Exception as exc:
+            logger.warning(
+                ":warning: get_column_lineage failed for %s: %s — skipping rename enrichment",
+                node.unique_id,
+                exc,
+            )
+            _LINEAGE_CACHE[cache_key] = []
+
+    lineage_results = _LINEAGE_CACHE[cache_key]
+
+    # Build a case-insensitive column lookup restricted to this node's results
+    lineage_by_col: dict[str, t.Any] = {
+        r.column.lower(): r for r in lineage_results if r.model == node.name
+    }
+    if not lineage_by_col:
+        logger.debug(
+            ":mag: No lineage results found for => %s",
+            node.unique_id,
+        )
+        return
+
+    # --- Enrich each column that is a rename ---
+    for col_name, node_col in node.columns.items():
+        lineage = lineage_by_col.get(col_name.lower())
+        if lineage is None or not lineage.is_rename:
+            logger.debug(
+                ":mag: %s.%s: not a rename, skipping",
+                node.name,
+                col_name,
+            )
+            continue
+
+        existing_desc = (node_col.description or "").strip()
+        is_placeholder = not existing_desc or existing_desc in context.placeholders
+        if not is_placeholder and not force_inherit:
+            logger.debug(
+                ":no_entry_sign: %s.%s has description and force_inherit=False, skipping",
+                node.name,
+                col_name,
+            )
+            continue
+
+        prefix = prefix_template.replace("{source_col}", lineage.source_column or "")
+        source_desc = _find_progenitor_description(
+            context, lineage.progenitor_model, lineage.progenitor_column
+        )
+        new_desc = f"{prefix} | {source_desc}" if source_desc else prefix
+
+        node.columns[col_name] = node_col.replace(description=new_desc)
+        logger.debug(
+            ":pencil: Enriched %s.%s => %r",
+            node.name,
+            col_name,
+            new_desc,
+        )
 
 
 def _collect_upstream_documents(

--- a/tests/core/test_inheritance_behavior.py
+++ b/tests/core/test_inheritance_behavior.py
@@ -413,6 +413,48 @@ def test_default_progenitor_override_reuses_selected_ancestor_knowledge(
     )
 
 
+def test_whitespace_only_description_inherits_from_upstream(yaml_context, fresh_caches):
+    """Whitespace-only local descriptions are treated as empty and inherit from upstream.
+
+    A column with description "   " should behave identically to one with description ""
+    — the whitespace is not considered real documentation, so upstream docs flow in.
+    """
+    manifest = yaml_context.project.manifest
+
+    stg_customers = manifest.nodes["model.jaffle_shop_duckdb.stg_customers.v1"]
+    stg_customers.columns["first_name"].description = "Customer first name"
+
+    customers = manifest.nodes["model.jaffle_shop_duckdb.customers"]
+    customers.columns["first_name"].description = "   "  # whitespace-only — should inherit
+
+    yaml_context.settings.force_inherit_descriptions = False
+    inherit_upstream_column_knowledge(yaml_context, customers)
+
+    assert customers.columns["first_name"].description == "Customer first name"
+
+
+def test_whitespace_only_upstream_description_does_not_propagate(yaml_context, fresh_caches):
+    """A whitespace-only description on an upstream column is not propagated downstream.
+
+    When the upstream source has a whitespace-only description it is stripped from the
+    graph edge during _clean_graph_edge, so the downstream column stays undocumented
+    rather than inheriting meaningless whitespace.
+    """
+    manifest = yaml_context.project.manifest
+
+    stg_customers = manifest.nodes["model.jaffle_shop_duckdb.stg_customers.v1"]
+    stg_customers.columns["first_name"].description = "   "  # whitespace-only upstream
+
+    customers = manifest.nodes["model.jaffle_shop_duckdb.customers"]
+    customers.columns["first_name"].description = ""
+
+    yaml_context.settings.force_inherit_descriptions = True
+    inherit_upstream_column_knowledge(yaml_context, customers)
+
+    # Whitespace-only upstream doc must not propagate; description stays empty/unchanged
+    assert not customers.columns["first_name"].description.strip()
+
+
 def test_column_default_progenitor_override_applies_without_progenitor_tracking(
     yaml_context,
     fresh_caches,

--- a/tests/core/test_rename_transform.py
+++ b/tests/core/test_rename_transform.py
@@ -1,0 +1,367 @@
+# pyright: reportPrivateImportUsage=false, reportPrivateUsage=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportAny=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportArgumentType=false, reportFunctionMemberAccess=false, reportUnknownVariableType=false, reportUnusedParameter=false
+"""Tests for the enrich_rename_descriptions transform.
+
+All tests use MagicMock — no DuckDB or warehouse connection required.
+
+dbt_column_lineage is stubbed into sys.modules before any imports so the
+package does not need to be installed in this virtualenv.
+
+`_get_setting_for_node` lives in dbt_osmosis.core.introspection and is
+imported locally inside each transform function body.  We patch the
+canonical location (dbt_osmosis.core.introspection._get_setting_for_node)
+so all local `from … import` calls resolve the patched version.
+
+`get_column_lineage` is likewise imported locally inside the transform body
+from dbt_column_lineage.api, so we patch that canonical location.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub dbt_column_lineage into sys.modules BEFORE importing transforms,
+# so the lazy local import inside the transform body always resolves.
+# ---------------------------------------------------------------------------
+_stub_api = types.ModuleType("dbt_column_lineage.api")
+_stub_api.get_column_lineage = MagicMock(return_value=[])  # type: ignore[attr-defined]
+_stub_root = types.ModuleType("dbt_column_lineage")
+sys.modules.setdefault("dbt_column_lineage", _stub_root)
+sys.modules.setdefault("dbt_column_lineage.api", _stub_api)
+
+from dbt_osmosis.core.transforms import (  # noqa: E402
+    _LINEAGE_CACHE,
+    _find_progenitor_description,
+    enrich_rename_descriptions,
+)
+
+# ---------------------------------------------------------------------------
+# Patch-target constants
+# _get_setting_for_node is imported locally in the function body via
+#   from dbt_osmosis.core.introspection import _get_setting_for_node
+# Patching the canonical location makes every local import resolve the mock.
+# ---------------------------------------------------------------------------
+_SETTING = "dbt_osmosis.core.introspection._get_setting_for_node"
+_GCL = "dbt_column_lineage.api.get_column_lineage"
+
+# ---------------------------------------------------------------------------
+# Shared placeholder tuple (must match the real value)
+# ---------------------------------------------------------------------------
+_PLACEHOLDERS = ("", "Pending further documentation", "No description for this column")
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+def _make_lineage_result(
+    model: str,
+    column: str,
+    *,
+    is_rename: bool = False,
+    source_column: str | None = None,
+    progenitor_model: str | None = None,
+    progenitor_column: str | None = None,
+) -> MagicMock:
+    r = MagicMock()
+    r.model = model
+    r.column = column
+    r.is_rename = is_rename
+    r.source_column = source_column
+    r.progenitor_model = progenitor_model
+    r.progenitor_column = progenitor_column
+    return r
+
+
+def _make_col(desc: str) -> MagicMock:
+    """Create a minimal ColumnInfo-like mock with a working .replace()."""
+    col = MagicMock()
+    col.description = desc
+
+    def _replace(**kw: str) -> MagicMock:
+        return _make_col(kw.get("description", desc))
+
+    col.replace = _replace
+    return col
+
+
+def _make_node(
+    name: str = "my_model",
+    resource_type: str = "model",
+    compiled_code: str | None = "select 1 as id",
+    columns: dict[str, str] | None = None,
+) -> MagicMock:
+    from dbt.artifacts.resources.types import NodeType
+
+    node = MagicMock()
+    node.unique_id = f"model.pkg.{name}"
+    node.name = name
+    node.resource_type = NodeType.Source if resource_type == "source" else NodeType.Model
+    node.compiled_code = compiled_code
+    node.compiled_sql = None  # ensure getattr fallback returns None too
+
+    node.columns = {col_name: _make_col(desc) for col_name, desc in (columns or {}).items()}
+    return node
+
+
+def _make_context(
+    project_dir: str = "/fake/project",
+    profiles_dir: str = "/fake/.dbt",
+    target: str | None = None,
+    force_inherit_descriptions: bool = False,
+    manifest_nodes: dict | None = None,
+) -> MagicMock:
+    ctx = MagicMock()
+    ctx.settings.force_inherit_descriptions = force_inherit_descriptions
+    ctx.placeholders = _PLACEHOLDERS
+    ctx.project.config.project_dir = project_dir
+    ctx.project.config.profiles_dir = profiles_dir
+    ctx.project.config.target = target
+    ctx.project.manifest.nodes = manifest_nodes or {}
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Fixture: clear the module-level lineage cache before each test
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clear_lineage_cache():
+    _LINEAGE_CACHE.clear()
+    yield
+    _LINEAGE_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Matrix: rename_descriptions × force_inherit_descriptions × existing_desc
+# ---------------------------------------------------------------------------
+
+@patch(_SETTING)
+def test_rename_descriptions_false_unchanged(mock_setting: MagicMock) -> None:
+    """rename_descriptions=False → column is never touched, lineage not fetched."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: (
+        False if name == "rename-descriptions" else fallback
+    )
+    node = _make_node(columns={"CUSTOMER_ID": ""})
+    ctx = _make_context()
+
+    with patch(_GCL) as mock_gcl:
+        enrich_rename_descriptions(ctx, node)
+
+    mock_gcl.assert_not_called()
+    assert node.columns["CUSTOMER_ID"].description == ""
+
+
+@patch(_SETTING)
+def test_rename_true_force_false_empty_desc_enriched(mock_setting: MagicMock) -> None:
+    """rename_descriptions=True, force=False, empty desc → rename enrichment applied."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: {
+        "rename-descriptions": True,
+        "force-inherit-descriptions": False,
+        "rename-description-prefix": "renamed from {source_col}",
+    }.get(name, fallback)
+
+    lineage = _make_lineage_result(
+        "my_model", "customer_id",
+        is_rename=True, source_column="id",
+        progenitor_model="stg_customers", progenitor_column="ID",
+    )
+    node = _make_node(columns={"customer_id": ""})
+    ctx = _make_context()
+
+    with patch(_GCL, return_value=[lineage]):
+        enrich_rename_descriptions(ctx, node)
+
+    assert node.columns["customer_id"].description == "renamed from id"
+
+
+@patch(_SETTING)
+def test_rename_true_force_false_nonempty_desc_skipped(mock_setting: MagicMock) -> None:
+    """rename_descriptions=True, force=False, non-empty desc → existing desc preserved."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: {
+        "rename-descriptions": True,
+        "force-inherit-descriptions": False,
+        "rename-description-prefix": "renamed from {source_col}",
+    }.get(name, fallback)
+
+    lineage = _make_lineage_result(
+        "my_model", "customer_id",
+        is_rename=True, source_column="id",
+    )
+    node = _make_node(columns={"customer_id": "Existing real description"})
+    ctx = _make_context()
+
+    with patch(_GCL, return_value=[lineage]):
+        enrich_rename_descriptions(ctx, node)
+
+    assert node.columns["customer_id"].description == "Existing real description"
+
+
+@patch(_SETTING)
+def test_rename_true_force_true_overwrites(mock_setting: MagicMock) -> None:
+    """rename_descriptions=True, force=True, any desc → rename enrichment applied."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: {
+        "rename-descriptions": True,
+        "force-inherit-descriptions": True,
+        "rename-description-prefix": "renamed from {source_col}",
+    }.get(name, fallback)
+
+    lineage = _make_lineage_result(
+        "my_model", "customer_id",
+        is_rename=True, source_column="id",
+    )
+    node = _make_node(columns={"customer_id": "Existing real description"})
+    ctx = _make_context()
+
+    with patch(_GCL, return_value=[lineage]):
+        enrich_rename_descriptions(ctx, node)
+
+    assert node.columns["customer_id"].description == "renamed from id"
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions
+# ---------------------------------------------------------------------------
+
+@patch(_SETTING)
+def test_source_node_skipped(mock_setting: MagicMock) -> None:
+    """Source nodes are silently skipped even when rename-descriptions=True."""
+    mock_setting.return_value = True
+
+    with patch(_GCL) as mock_gcl:
+        node = _make_node(resource_type="source", columns={"id": ""})
+        enrich_rename_descriptions(_make_context(), node)
+
+    mock_gcl.assert_not_called()
+
+
+@patch(_SETTING)
+def test_no_compiled_sql_skipped(mock_setting: MagicMock) -> None:
+    """Ephemeral-like nodes without compiled SQL are silently skipped."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: (
+        True if name == "rename-descriptions" else fallback
+    )
+
+    with patch(_GCL) as mock_gcl:
+        node = _make_node(compiled_code=None, columns={"id": ""})
+        enrich_rename_descriptions(_make_context(), node)
+
+    mock_gcl.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Prefix template behaviour
+# ---------------------------------------------------------------------------
+
+@patch(_SETTING)
+def test_prefix_joined_with_progenitor_desc(mock_setting: MagicMock) -> None:
+    """Prefix and progenitor description are joined with ' | ' when both exist."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: {
+        "rename-descriptions": True,
+        "force-inherit-descriptions": False,
+        "rename-description-prefix": "renamed from {source_col}",
+    }.get(name, fallback)
+
+    progenitor_col = MagicMock()
+    progenitor_col.description = "The unique customer identifier"
+    progenitor_node = MagicMock()
+    progenitor_node.name = "stg_customers"
+    progenitor_node.columns = {"ID": progenitor_col}
+
+    lineage = _make_lineage_result(
+        "my_model", "customer_id",
+        is_rename=True, source_column="id",
+        progenitor_model="stg_customers", progenitor_column="ID",
+    )
+    node = _make_node(columns={"customer_id": ""})
+    ctx = _make_context(manifest_nodes={"model.pkg.stg_customers": progenitor_node})
+
+    with patch(_GCL, return_value=[lineage]):
+        enrich_rename_descriptions(ctx, node)
+
+    assert node.columns["customer_id"].description == (
+        "renamed from id | The unique customer identifier"
+    )
+
+
+@patch(_SETTING)
+def test_custom_prefix_template(mock_setting: MagicMock) -> None:
+    """Custom rename-description-prefix is applied with {source_col} substituted."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: {
+        "rename-descriptions": True,
+        "force-inherit-descriptions": False,
+        "rename-description-prefix": "aliased: {source_col}",
+    }.get(name, fallback)
+
+    lineage = _make_lineage_result(
+        "my_model", "cust_id",
+        is_rename=True, source_column="customer_id",
+    )
+    node = _make_node(columns={"cust_id": ""})
+
+    with patch(_GCL, return_value=[lineage]):
+        enrich_rename_descriptions(_make_context(), node)
+
+    assert node.columns["cust_id"].description == "aliased: customer_id"
+
+
+# ---------------------------------------------------------------------------
+# Resilience
+# ---------------------------------------------------------------------------
+
+@patch(_SETTING)
+def test_lineage_failure_is_graceful(mock_setting: MagicMock) -> None:
+    """If get_column_lineage raises, the node is skipped without propagating."""
+    mock_setting.side_effect = lambda name, node, *a, fallback=None, **kw: (
+        True if name == "rename-descriptions" else fallback
+    )
+
+    with patch(_GCL, side_effect=RuntimeError("adapter timeout")):
+        node = _make_node(columns={"id": ""})
+        enrich_rename_descriptions(_make_context(), node)  # must not raise
+
+    assert node.columns["id"].description == ""
+
+
+# ---------------------------------------------------------------------------
+# _find_progenitor_description unit tests
+# ---------------------------------------------------------------------------
+
+def test_find_progenitor_description_found() -> None:
+    col = MagicMock()
+    col.description = "The primary key"
+    upstream = MagicMock()
+    upstream.name = "stg_orders"
+    upstream.columns = {"ORDER_ID": col}
+    ctx = _make_context(manifest_nodes={"model.pkg.stg_orders": upstream})
+    assert _find_progenitor_description(ctx, "stg_orders", "ORDER_ID") == "The primary key"
+
+
+def test_find_progenitor_description_case_insensitive() -> None:
+    col = MagicMock()
+    col.description = "The primary key"
+    upstream = MagicMock()
+    upstream.name = "stg_orders"
+    upstream.columns = {"ORDER_ID": col}
+    ctx = _make_context(manifest_nodes={"model.pkg.stg_orders": upstream})
+    # lowercase lookup must still resolve
+    assert _find_progenitor_description(ctx, "stg_orders", "order_id") == "The primary key"
+
+
+def test_find_progenitor_description_placeholder_returns_none() -> None:
+    col = MagicMock()
+    col.description = ""  # placeholder
+    upstream = MagicMock()
+    upstream.name = "stg_orders"
+    upstream.columns = {"ORDER_ID": col}
+    ctx = _make_context(manifest_nodes={"model.pkg.stg_orders": upstream})
+    assert _find_progenitor_description(ctx, "stg_orders", "ORDER_ID") is None
+
+
+def test_find_progenitor_description_no_model_returns_none() -> None:
+    ctx = _make_context()
+    assert _find_progenitor_description(ctx, "nonexistent_model", "col") is None


### PR DESCRIPTION
  - Whitespace-only descriptions are now treated as empty throughout the inheritance pipeline (inheritance.py, transforms.py), preventing
  silent propagation of blank strings that blocked legitimate upstream docs from flowing down
  - Normalizes FoldedScalarString values to plain str before writing back into the YAML document (sync_operations.py), and sets best_width explicitly on the YAML instance (parser.py) — together these make consecutive refactor runs produce identical output instead of oscillating between fold-point layouts

  Test plan

  - Run yaml refactor twice on a project with multi-line descriptions and confirm output is identical on both runs
  - Verify columns with whitespace-only descriptions ("   ") correctly inherit upstream documentation
  - Run existing test suite: uv run pytest