### PR TITLE
feat: vars-based per-folder YAML routing for dbt-fusion compatibility

### DIFF
--- a/FUSION_COMPAT.md
+++ b/FUSION_COMPAT.md
@@ -2,7 +2,7 @@
 
 Tracked from real-world testing on [oem-dbt-bigquery](https://github.com/RicardoAGL/oem-dbt-bigquery) (BigQuery, Kimball star schema, 15+ models).
 
-dbt-fusion version: **2.0.0-preview.154**
+dbt-fusion version: **2.0.0-preview.154** | dbt-core 1.12.0b2 + dbt-core-experimental-parser 2.0.0a1 (tested 2026-06-01)
 
 ---
 
@@ -58,6 +58,76 @@ vars:
 Routing matches against the node's FQN folder path. For nested folders, use dot notation (e.g., `staging.oem_raw`). The most specific match wins. Existing `+dbt-osmosis` config keys still take priority for backward compatibility.
 
 **Status**: Implemented in `feat/fusion-vars-routing` branch. 18 tests passing (16 unit + 2 integration). 678 total tests green.
+
+---
+
+## Finding 4: `vars.yml` external file — dbt-core 1.12 / 2.0 forward-compatibility
+
+**Severity**: None (osmosis already compatible, see below)
+**Introduced in**: dbt-core 1.12.0b1 (Python) and dbt-core 2.0.0a1 (Rust/Fusion)
+**Behavior**: Projects may now declare `vars:` in a standalone `vars.yml` file at the project root instead of inside `dbt_project.yml`.
+
+### Mutual exclusion rule
+
+`vars.yml` and `dbt_project.yml`'s `vars:` key are mutually exclusive. Both defined simultaneously raises `DbtProjectError`. Pick one location.
+
+```
+# vars.yml (new option, dbt-core 1.12+)
+vars:
+  dbt-osmosis:
+    models:
+      staging: "_stg_{parent}__models.yml"
+
+# OR dbt_project.yml (existing option — remove if using vars.yml)
+vars:
+  dbt-osmosis:
+    models:
+      staging: "_stg_{parent}__models.yml"
+```
+
+### Scope clarification: `+meta:` keys vs `vars:`
+
+These are two separate config surfaces and do **not** conflict:
+
+| Config key | Location | Subject to mutual exclusion? | Used by osmosis for |
+| ---------- | -------- | ---------------------------- | ------------------- |
+| `models.*.+dbt-osmosis: "..."` | `dbt_project.yml` only | No | Routing (legacy, breaks fusion parser) |
+| `models.*.+meta: {dbt-osmosis: "..."}` | `dbt_project.yml` only | No | Routing (still works, but see Finding 1) |
+| `vars.dbt-osmosis.models.*` | `dbt_project.yml` OR `vars.yml` | Yes (pick one) | Routing (fusion-compatible) |
+
+The `+meta: dbt-osmosis:` config keys **stay in `dbt_project.yml`** regardless — they are model config properties, not vars. Only the top-level `vars:` key is subject to the mutual exclusion rule.
+
+### osmosis impact: none — VarProvider API is unchanged
+
+`_resolve_vars_routing` reads vars via `context.project.runtime_cfg.vars.to_dict()`. The `VarProvider` interface returned by `runtime_cfg.vars` is unchanged in dbt-core 1.12 and 2.0 regardless of which file the vars came from. No code change needed.
+
+CLI `--vars` is also unaffected — it deep-merges on top of `vars.yml` at load time, so by the time osmosis reads `runtime_cfg.vars`, the merged result is already there.
+
+### Migration guide for users moving to `vars.yml`
+
+1. Create `vars.yml` at project root:
+   ```yaml
+   vars:
+     dbt-osmosis:
+       models:
+         staging: "_stg_{parent}__models.yml"
+         intermediate: "_int_{parent}__models.yml"
+         marts: "_marts_{parent}__models.yml"
+       seeds: "_seeds__models.yml"
+   ```
+2. Remove the `vars:` block from `dbt_project.yml` (mutual exclusion enforced).
+3. The `+meta: dbt-osmosis:` and `+dbt-osmosis:` keys in your models config are unrelated — leave or remove them per Finding 1 guidance.
+
+### Empirical test results (2026-06-01, oem-dbt-bigquery)
+
+| Test | Result |
+| ---- | ------ |
+| `dbt parse` (Python, 1.12.0b2) with `vars.yml` | PASS |
+| `dbt parse --use-v2-parser` (Rust, 2.0.0a1) with `vars.yml` | PASS (208ms) |
+| `dbt-osmosis yaml refactor --fusion-compat --dry-run` reading from `vars.yml` | PASS (0 ops — routing resolved correctly) |
+| Mutual exclusion: `vars:` in both files | `DbtProjectError` as documented |
+
+**Status**: No code change needed in osmosis. Document only.
 
 ---
 
@@ -230,3 +300,6 @@ Osmosis depends on dbt-core at 4 levels:
 | `dbtf build --write-catalog` | PARTIAL -- catalog.json generated but empty (BQ permission bug) |
 | `dbt docs generate` (core) | PASS -- 30.9K catalog with full column metadata |
 | osmosis vars routing | PASS -- 18 tests (feat/fusion-vars-routing branch) |
+| `dbt parse` (1.12.0b2) + `vars.yml` | PASS (2026-06-01) |
+| `dbt parse --use-v2-parser` (2.0.0a1) + `vars.yml` | PASS 208ms (2026-06-01) |
+| osmosis reads routing from `vars.yml` | PASS -- 0 ops, routes identical to dbt_project.yml vars (2026-06-01) |

--- a/FUSION_COMPAT.md
+++ b/FUSION_COMPAT.md
@@ -117,12 +117,15 @@ tests:
 
 ---
 
-## Performance
+## Performance (tested 2026-03-22, oem-dbt-bigquery, 16 models + 34 tests + 5 seeds)
 
 | Operation | dbt-core 1.11.7 | dbt-fusion 2.0.0-preview.154 |
 | --------- | ---------------- | ---------------------------- |
-| Parse     | ~2.0s            | 637ms (3.1x faster)          |
-| Build     | ~30s             | Not tested (parse must pass)  |
+| Parse     | ~2.0s            | 854ms (2.3x faster)          |
+| Build     | ~30s             | 62s (includes catalog gen)    |
+| Build (no catalog) | ~30s    | ~50s (estimated)              |
+
+Note: fusion build includes `--write-catalog` overhead. The 55/55 pass rate is identical to core.
 
 ---
 
@@ -160,36 +163,70 @@ vars:
 
 The `vars:` section is standard dbt -- both core and fusion accept it. Routing matches against the node's FQN folder path, with most-specific match winning (e.g., `staging.oem_raw` beats `staging`). Existing `+dbt-osmosis` config keys still take priority for backward compatibility.
 
-### Other options (not yet needed)
+### Fusion artifact compatibility (tested 2026-03-22)
 
-1. **Fusion allows unknown `+` prefixed keys** (fusion-side): Contribute a fix to fusion. May be on their roadmap.
+| Artifact | Fusion produces? | Format | Compatible with osmosis? |
+| -------- | ---------------- | ------ | ----------------------- |
+| manifest.json | Yes | v12 (same as core) | Yes -- osmosis can read it |
+| catalog.json | Yes (`--write-catalog`) | v1 (same as core) | No -- empty due to TABLE_STORAGE permission bug |
+| run_results.json | Yes | v6 (same as core) | N/A |
+| semantic_manifest.json | Yes | Standard | N/A |
 
-2. **osmosis reads fusion artifacts instead of core** (medium effort): If fusion produces a compatible `manifest.json`, osmosis could read that instead of calling dbt-core.
+**Key finding**: Fusion's `--write-catalog` queries `INFORMATION_SCHEMA.TABLE_STORAGE` which requires additional BigQuery permissions. Core's `dbt docs generate` uses a different query path that works with standard `dataEditor` + `jobUser` roles. This is likely a fusion bug or missing macro override for BigQuery.
 
-3. **Rust port of osmosis** (high effort, high payoff): Rewrite in Rust, using fusion's parser. Most aligned with where dbt is heading.
+**Workaround**: Use `dbt docs generate` (core) to produce the catalog, then use fusion for everything else.
 
-### Recommendation for OEM project (immediate)
+### dbt-core dependency analysis
 
-For the OEM project specifically:
-- **Remove osmosis from pre-commit and CI** until the `+dbt-osmosis` key issue is resolved
-- Keep osmosis installed locally for manual YAML management if needed
-- All new models validate with `dbtf parse` as the source of truth
-- Track fusion compat issues in this file
-- First fix to try: option 1 (move routing config to `.dbt-osmosis.yml` or `meta:`)
+Osmosis depends on dbt-core at 4 levels:
 
-### Questions to answer
+| Level | What | Can replace with fusion? |
+| ----- | ---- | ----------------------- |
+| Engine | Parse project, load manifest | Yes -- read fusion's manifest.json instead |
+| Catalog | Query warehouse for column metadata | Not yet -- fusion catalog empty (permission bug) |
+| SQL compilation | SqlCompileRunner, process_node | No -- fusion has no Python API |
+| Data types | ResultNode, NodeType, ColumnInfo | No -- used in every function signature |
 
-- Does fusion produce a `manifest.json`? If so, is the schema compatible with what osmosis reads?
-- Does `dbt-osmosis yaml refactor --fusion-compat` actually produce fusion-valid output? (Test with `dbtf parse` after running it)
-- Can osmosis work with fusion's catalog instead of calling `dbt docs generate` on core?
+**Bottom line**: Osmosis cannot run without dbt-core today. The hybrid approach (both engines installed) is the practical path.
+
+### Other options (future)
+
+1. **Read fusion manifest instead of re-parsing** (medium effort): Since fusion produces v12 manifests, osmosis could skip its own `dbt parse` and read from disk. Still needs core for catalog.
+
+2. **Fusion fixes TABLE_STORAGE bug** (fusion-side): Once fusion's catalog works on BigQuery, osmosis could use it instead of `dbt docs generate`.
+
+3. **Manifest-only mode** (medium effort): Osmosis reads manifest + catalog from disk without invoking core's parser. Core only needed for SQL compilation.
+
+4. **Rust port** (high effort): Rewrite as fusion plugin. Maximum performance, zero Python dependency.
+
+### Recommendation for OEM project
+
+- **Use `dbtf build` as primary engine** -- all 55 nodes pass
+- **Use `dbt docs generate` (core) for catalog** -- needed until fusion catalog bug is fixed
+- **Use vars-based routing** -- `+dbt-osmosis` keys replaced with `vars.dbt-osmosis.models`
+- **Validate with `dbtf parse`** as source of truth for YAML correctness
+- osmosis can be used for YAML management in the hybrid setup
+
+### Questions answered
+
+- **Does fusion produce manifest.json?** Yes, v12 schema, fully compatible with core and osmosis.
+- **Does fusion produce catalog.json?** Yes with `--write-catalog`, but empty on BigQuery due to TABLE_STORAGE permission query. Needs bug report or permission fix.
+- **Can osmosis work without core?** No. Needs core for catalog generation and SQL compilation. Manifest can be read from fusion.
+
+### Remaining questions
+
+- Does `dbt-osmosis yaml refactor --fusion-compat` produce fusion-valid output? (Test with `dbtf parse` after running it)
+- dbt MCP server -- does it work with fusion artifacts?
+- ModuLens -- can it read fusion-generated manifest/catalog?
 
 ---
 
-## Test Plan
+## Test Plan Results (2026-03-22)
 
-Once parse errors are fixed:
-1. `dbtf build` -- does it compile and run against BigQuery?
-2. `dbtf test` -- do all 55 tests pass?
-3. `dbt-osmosis yaml refactor --fusion-compat` then `dbtf parse` -- does osmosis output pass fusion?
-4. dbt MCP server -- does it work with fusion artifacts?
-5. ModuLens -- can it read fusion-generated manifest/catalog?
+| Test | Result |
+| ---- | ------ |
+| `dbtf parse` | PASS -- 0 errors after fixing freshness, test args, and +dbt-osmosis keys |
+| `dbtf build` | PASS -- 55/55 (16 models, 34 tests, 5 seeds) |
+| `dbtf build --write-catalog` | PARTIAL -- catalog.json generated but empty (BQ permission bug) |
+| `dbt docs generate` (core) | PASS -- 30.9K catalog with full column metadata |
+| osmosis vars routing | PASS -- 18 tests (feat/fusion-vars-routing branch) |

--- a/FUSION_COMPAT.md
+++ b/FUSION_COMPAT.md
@@ -1,0 +1,195 @@
+# dbt-fusion Compatibility Findings
+
+Tracked from real-world testing on [oem-dbt-bigquery](https://github.com/RicardoAGL/oem-dbt-bigquery) (BigQuery, Kimball star schema, 15+ models).
+
+dbt-fusion version: **2.0.0-preview.154**
+
+---
+
+## Finding 1: `+dbt-osmosis` config keys rejected by fusion parser
+
+**Severity**: Blocking (parse fails)
+**dbt-core behavior**: Ignores unknown `+` prefixed keys in `dbt_project.yml`
+**dbt-fusion behavior**: Strict schema validation rejects them as invalid config
+
+```
+error: dbt1013: Invalid model definition `oem_data_platform.staging.+dbt-osmosis`:
+  invalid type: string "_stg_{parent}__models.yml", expected struct ProjectModelConfig
+  --> dbt_project.yml:25:21
+```
+
+**Affected config** (from `dbt_project.yml`):
+```yaml
+models:
+  oem_data_platform:
+    staging:
+      +dbt-osmosis: "_stg_{parent}__models.yml"
+    intermediate:
+      +dbt-osmosis: "_int_{parent}__models.yml"
+    marts:
+      +dbt-osmosis: "_marts_{parent}__models.yml"
+seeds:
+  +dbt-osmosis: "_seeds__models.yml"
+```
+
+**Impact on osmosis**: dbt-osmosis uses these keys to route YAML schema files. If fusion rejects them, projects that use both osmosis and fusion cannot parse. This is the most critical compat issue for the osmosis + fusion combination.
+
+**Solution implemented**: Move routing config to `vars.dbt-osmosis.models` in `dbt_project.yml`. The `vars:` section is standard dbt and accepted by both core and fusion.
+
+**Before** (breaks fusion):
+```yaml
+models:
+  oem_data_platform:
+    staging:
+      +dbt-osmosis: "_stg_{parent}__models.yml"
+```
+
+**After** (works with both core and fusion):
+```yaml
+vars:
+  dbt-osmosis:
+    models:
+      staging: "_stg_{parent}__models.yml"
+      intermediate: "_int_{parent}__models.yml"
+      marts: "_marts_{parent}__models.yml"
+    seeds: "_seeds__models.yml"
+```
+
+Routing matches against the node's FQN folder path. For nested folders, use dot notation (e.g., `staging.oem_raw`). The most specific match wins. Existing `+dbt-osmosis` config keys still take priority for backward compatibility.
+
+**Status**: Implemented in `feat/fusion-vars-routing` branch. 18 tests passing (16 unit + 2 integration). 678 total tests green.
+
+---
+
+## Finding 2: Source freshness syntax must use `config:` block
+
+**Severity**: Blocking (parse fails)
+**dbt-core behavior**: Warns (deprecated), still works
+**dbt-fusion behavior**: Rejects as unexpected key
+
+```
+error: dbt1060: Ignored unexpected key `"freshness"`. YAML path: `freshness`.
+  --> models/staging/oem_raw/_src_oem_raw.yml:10:5
+error: dbt1060: Ignored unexpected key `"loaded_at_field"`. YAML path: `loaded_at_field`.
+  --> models/staging/oem_raw/_src_oem_raw.yml:13:5
+```
+
+**Fix**: Move `freshness` and `loaded_at_field` into `config:` block per dbt 1.9+ syntax. This is a known deprecation that core still accepts but fusion enforces.
+
+**Impact on osmosis**: If osmosis generates or reads freshness config at the old location, it needs to handle the new `config:` location too. Check if `yaml refactor` handles this migration.
+
+**Status**: Fix is straightforward in the project; osmosis needs testing
+
+---
+
+## Finding 3: Deprecated test argument format
+
+**Severity**: Blocking (parse fails)
+**dbt-core behavior**: Warns (deprecated), still works
+**dbt-fusion behavior**: Rejects
+
+```
+error: dbt0102: Deprecated test arguments: ["field", "to"] at top-level detected.
+  Please migrate to the new format under the 'arguments' field.
+  --> models/marts/_marts_marts__models.yml:201:22
+```
+
+**Old format** (core accepts, fusion rejects):
+```yaml
+tests:
+  - relationships:
+      to: ref('dim_date')
+      field: date_key
+```
+
+**New format** (both accept):
+```yaml
+tests:
+  - relationships:
+      arguments:
+        to: ref('dim_date')
+        field: date_key
+```
+
+**Impact on osmosis**: Check if `yaml refactor` generates old or new format. If old, osmosis needs a flag or default to emit fusion-compatible syntax. The `--fusion-compat` flag may already handle this -- needs verification.
+
+**Status**: Fix is straightforward in the project; osmosis `--fusion-compat` needs testing
+
+---
+
+## Performance
+
+| Operation | dbt-core 1.11.7 | dbt-fusion 2.0.0-preview.154 |
+| --------- | ---------------- | ---------------------------- |
+| Parse     | ~2.0s            | 637ms (3.1x faster)          |
+| Build     | ~30s             | Not tested (parse must pass)  |
+
+---
+
+## Architectural Problem: osmosis depends on dbt-core internals
+
+This is the biggest challenge. dbt-osmosis uses dbt-core's Python engine internally (manifest parsing, adapter calls, YAML generation). It does not just read/write YAML files -- it calls into dbt-core to resolve refs, compile SQL, and understand the project graph.
+
+This means:
+- **osmosis requires dbt-core as a Python dependency** -- you cannot uninstall core and run osmosis alone
+- **In a fusion project, you have two engines**: fusion (Rust, fast, strict) and core (Python, slower, lenient). They may disagree on what is valid.
+- **osmosis-generated YAML may be valid for core but invalid for fusion** (Finding 1 and 3 above are examples)
+
+### The hybrid approach (documented in this fork)
+
+The intended workflow is: **install both core and fusion**. Osmosis uses dbt-core internally to resolve the project graph and generate YAML schemas. The output targets the fusion project. This works for most things -- osmosis reads models, resolves columns, writes YAML that fusion can consume.
+
+**The catch**: `dbt_project.yml` is shared by both engines. Osmosis stores its routing config there as `+dbt-osmosis` keys. Core ignores unknown `+` prefixed keys. Fusion's strict parser rejects them. This is the one file where the hybrid breaks.
+
+### Solution: vars-based routing (implemented)
+
+The `feat/fusion-vars-routing` branch adds a new resolution step in `_get_yaml_path_template` (path_management.py). Instead of requiring `+dbt-osmosis` config keys, users can place routing under `vars.dbt-osmosis.models`:
+
+```yaml
+vars:
+  dbt-osmosis:
+    models:
+      staging: "_stg_{parent}__models.yml"
+      intermediate: "_int_{parent}__models.yml"
+      marts: "_marts_{parent}__models.yml"
+    seeds: "_seeds__models.yml"
+    sources:
+      oem_raw:
+        path: "staging/oem_raw/_src_oem_raw.yml"
+```
+
+The `vars:` section is standard dbt -- both core and fusion accept it. Routing matches against the node's FQN folder path, with most-specific match winning (e.g., `staging.oem_raw` beats `staging`). Existing `+dbt-osmosis` config keys still take priority for backward compatibility.
+
+### Other options (not yet needed)
+
+1. **Fusion allows unknown `+` prefixed keys** (fusion-side): Contribute a fix to fusion. May be on their roadmap.
+
+2. **osmosis reads fusion artifacts instead of core** (medium effort): If fusion produces a compatible `manifest.json`, osmosis could read that instead of calling dbt-core.
+
+3. **Rust port of osmosis** (high effort, high payoff): Rewrite in Rust, using fusion's parser. Most aligned with where dbt is heading.
+
+### Recommendation for OEM project (immediate)
+
+For the OEM project specifically:
+- **Remove osmosis from pre-commit and CI** until the `+dbt-osmosis` key issue is resolved
+- Keep osmosis installed locally for manual YAML management if needed
+- All new models validate with `dbtf parse` as the source of truth
+- Track fusion compat issues in this file
+- First fix to try: option 1 (move routing config to `.dbt-osmosis.yml` or `meta:`)
+
+### Questions to answer
+
+- Does fusion produce a `manifest.json`? If so, is the schema compatible with what osmosis reads?
+- Does `dbt-osmosis yaml refactor --fusion-compat` actually produce fusion-valid output? (Test with `dbtf parse` after running it)
+- Can osmosis work with fusion's catalog instead of calling `dbt docs generate` on core?
+
+---
+
+## Test Plan
+
+Once parse errors are fixed:
+1. `dbtf build` -- does it compile and run against BigQuery?
+2. `dbtf test` -- do all 55 tests pass?
+3. `dbt-osmosis yaml refactor --fusion-compat` then `dbtf parse` -- does osmosis output pass fusion?
+4. dbt MCP server -- does it work with fusion artifacts?
+5. ModuLens -- can it read fusion-generated manifest/catalog?

--- a/docs/docs/tutorial-yaml/configuration.md
+++ b/docs/docs/tutorial-yaml/configuration.md
@@ -55,6 +55,26 @@ Seeds can be a single string (applies to all seeds) or a dict with per-folder ke
 
 **Precedence**: `+dbt-osmosis` config keys (if present) take priority over vars routing. This means existing dbt-core projects keep working unchanged -- vars routing is only used when the config key is absent.
 
+### Placing vars in `vars.yml` (dbt-core 1.12+)
+
+dbt-core 1.12 and dbt-core 2.0 (Fusion) support an external `vars.yml` file at the project root as an alternative to the `vars:` key in `dbt_project.yml`. dbt-osmosis reads from both locations transparently -- no configuration change is needed in osmosis itself.
+
+To use `vars.yml`, create the file and move the `dbt-osmosis` vars block there:
+
+```yaml title="vars.yml"
+vars:
+  dbt-osmosis:
+    models:
+      staging: "_stg_{parent}__models.yml"
+      intermediate: "_int_{parent}__models.yml"
+      marts: "_marts_{parent}__models.yml"
+    seeds: "_seeds__models.yml"
+```
+
+Then remove the `vars:` block from `dbt_project.yml`. The two locations are mutually exclusive -- having `vars:` defined in both files raises a `DbtProjectError` at parse time.
+
+Note that `+meta: {dbt-osmosis: ...}` and `+dbt-osmosis:` model config keys are separate from the `vars:` block and are not affected by this rule. Those keys live in `dbt_project.yml` regardless of where vars are declared.
+
 ### Sources
 
 Configure managed sources under `vars.dbt-osmosis.sources`:

--- a/docs/docs/tutorial-yaml/configuration.md
+++ b/docs/docs/tutorial-yaml/configuration.md
@@ -35,6 +35,26 @@ vars:
   dbt_osmosis_default_path: "_{model}.yml"
 ```
 
+### Fusion-Compatible Routing via `vars`
+
+If you use **dbt-fusion**, the `+dbt-osmosis` config keys in `dbt_project.yml` will cause parse errors because fusion's strict parser rejects unknown `+` prefixed keys. As an alternative, you can specify per-folder routing under `vars.dbt-osmosis.models`:
+
+```yaml title="dbt_project.yml"
+vars:
+  dbt-osmosis:
+    models:
+      staging: "_stg_{parent}__models.yml"
+      intermediate: "_int_{parent}__models.yml"
+      marts: "_marts_{parent}__models.yml"
+    seeds: "_seeds__models.yml"
+```
+
+This is functionally equivalent to `+dbt-osmosis` config keys but uses `vars:`, which both dbt-core and dbt-fusion accept. Routing matches against the node's FQN folder path -- a model in `models/staging/oem_raw/` matches the `staging` key. For nested folders, use dot notation (`staging.oem_raw`) -- the most specific match wins.
+
+Seeds can be a single string (applies to all seeds) or a dict with per-folder keys like models.
+
+**Precedence**: `+dbt-osmosis` config keys (if present) take priority over vars routing. This means existing dbt-core projects keep working unchanged -- vars routing is only used when the config key is absent.
+
 ### Sources
 
 Configure managed sources under `vars.dbt-osmosis.sources`:

--- a/src/dbt_osmosis/core/path_management.py
+++ b/src/dbt_osmosis/core/path_management.py
@@ -19,6 +19,7 @@ __all__ = [
     "SchemaFileLocation",
     "SchemaFileMigration",
     "_get_yaml_path_template",
+    "_resolve_vars_routing",
     "build_yaml_file_mapping",
     "create_missing_source_yamls",
     "get_current_yaml_path",
@@ -52,11 +53,82 @@ class SchemaFileMigration:
     supersede: dict[Path, list[ResultNode]] = field(default_factory=dict)
 
 
+def _resolve_vars_routing(
+    context: YamlRefactorContextProtocol,
+    node: ResultNode,
+) -> str | None:
+    """Resolve YAML path template from vars.dbt-osmosis.models (or .seeds).
+
+    This is the fusion-compatible alternative to +dbt-osmosis config keys in
+    dbt_project.yml. Since dbt-fusion rejects unknown + prefixed keys but accepts
+    vars, users can move their routing config here:
+
+        vars:
+          dbt-osmosis:
+            models:
+              staging: "_stg_{parent}__models.yml"
+              intermediate: "_int_{parent}__models.yml"
+              marts: "_marts_{parent}__models.yml"
+            seeds: "_seeds__models.yml"
+
+    Matching uses the node's FQN (fully qualified name). For a model with
+    fqn = ["project", "staging", "oem_raw", "stg_oem_raw__mme"], we check
+    the routing dict for the most specific match first:
+      1. "staging.oem_raw" (deepest folder path)
+      2. "staging" (parent folder)
+
+    For seeds, the value can be a string (applies to all seeds) or a dict
+    with per-folder routing like models.
+    """
+    try:
+        project_vars = context.project.runtime_cfg.vars.to_dict()
+    except Exception:
+        return None
+
+    osmosis_vars = project_vars.get("dbt-osmosis", project_vars.get("dbt_osmosis", {}))
+    if not isinstance(osmosis_vars, dict):
+        return None
+
+    # Determine which routing section to use
+    if node.resource_type == NodeType.Seed:
+        routing = osmosis_vars.get("seeds")
+        if isinstance(routing, str):
+            return routing
+        if not isinstance(routing, dict):
+            return None
+    else:
+        routing = osmosis_vars.get("models")
+        if not isinstance(routing, dict):
+            return None
+
+    # FQN is ["project_name", "folder1", "folder2", ..., "model_name"]
+    # We match against folder parts only (index 1 to -1), most specific first
+    fqn_folders = node.fqn[1:-1] if len(node.fqn) > 2 else []
+
+    # Try most-specific first: "staging.oem_raw", then "staging"
+    for depth in range(len(fqn_folders), 0, -1):
+        key = ".".join(fqn_folders[:depth])
+        if key in routing:
+            value = routing[key]
+            if isinstance(value, str):
+                logger.debug(
+                    ":rocket: Resolved YAML path from vars routing [%s]: %s",
+                    key,
+                    value,
+                )
+                return value
+
+    return None
+
+
 def _get_yaml_path_template(context: YamlRefactorContextProtocol, node: ResultNode) -> str | None:
     """Get the yaml path template for a dbt model or source node.
 
-    First checks for a model-specific `+dbt-osmosis` config via SettingsResolver,
-    then falls back to the global `dbt_osmosis_default_path` var from dbt_project.yml.
+    Resolution order:
+    1. Source definitions (vars.dbt-osmosis.sources) for source nodes
+    2. SettingsResolver: node.config.extra, config.meta, node.meta, unrendered_config
+    3. vars.dbt-osmosis.models / .seeds per-folder routing (fusion-compatible)
+    4. vars.dbt_osmosis_default_path global fallback
     """
     from dbt_osmosis.core.introspection import SettingsResolver
 
@@ -74,7 +146,11 @@ def _get_yaml_path_template(context: YamlRefactorContextProtocol, node: ResultNo
     raw_path_template = resolver.get_yaml_path_template(node)
     path_template = raw_path_template if isinstance(raw_path_template, str) else None
 
-    # If no model-specific config, check for global var
+    # If no model-specific config, try vars-based per-folder routing (fusion-compatible)
+    if not path_template:
+        path_template = _resolve_vars_routing(context, node)
+
+    # If still no match, check for global var fallback
     if not path_template:
         try:
             project_vars = context.project.runtime_cfg.vars.to_dict()
@@ -92,7 +168,8 @@ def _get_yaml_path_template(context: YamlRefactorContextProtocol, node: ResultNo
 
     if not path_template:
         raise MissingOsmosisConfig(
-            f"Config key `+dbt-osmosis:` or var `dbt_osmosis_default_path` not set for model {node.name}",
+            f"Config key `+dbt-osmosis:`, var `dbt_osmosis_default_path`,"
+            f" or vars.dbt-osmosis.models not set for model {node.name}",
         )
     if not isinstance(path_template, str):
         return None

--- a/src/dbt_osmosis/core/path_management.py
+++ b/src/dbt_osmosis/core/path_management.py
@@ -82,7 +82,7 @@ def _resolve_vars_routing(
     """
     try:
         project_vars = context.project.runtime_cfg.vars.to_dict()
-    except Exception:
+    except (AttributeError, TypeError, RuntimeError):
         return None
 
     osmosis_vars = project_vars.get("dbt-osmosis", project_vars.get("dbt_osmosis", {}))

--- a/tests/core/test_vars_routing.py
+++ b/tests/core/test_vars_routing.py
@@ -1,0 +1,322 @@
+# pyright: reportPrivateImportUsage=false, reportPrivateUsage=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportAny=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportArgumentType=false, reportFunctionMemberAccess=false, reportUnknownVariableType=false, reportUnusedParameter=false
+
+"""Tests for vars-based per-folder YAML routing (fusion-compatible).
+
+These tests validate _resolve_vars_routing which allows users to specify
+YAML path templates under vars.dbt-osmosis.models instead of +dbt-osmosis
+config keys in dbt_project.yml. This is needed for dbt-fusion compatibility
+since fusion rejects unknown + prefixed config keys.
+"""
+
+from __future__ import annotations
+
+import typing as t
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from dbt.artifacts.resources.types import NodeType
+
+from dbt_osmosis.core.path_management import (
+    MissingOsmosisConfig,
+    _resolve_vars_routing,
+)
+
+
+def _make_node(
+    fqn: list[str],
+    resource_type: NodeType = NodeType.Model,
+    name: str | None = None,
+) -> MagicMock:
+    """Create a minimal mock node with the given FQN."""
+    node = MagicMock()
+    node.fqn = fqn
+    node.resource_type = resource_type
+    node.name = name or fqn[-1]
+    node.config = MagicMock()
+    node.config.extra = {}
+    node.unrendered_config = {}
+    node.meta = {}
+    return node
+
+
+def _make_context(vars_dict: dict[str, t.Any]) -> MagicMock:
+    """Create a minimal mock context with the given project vars."""
+    context = MagicMock()
+    context.project.runtime_cfg.vars.to_dict.return_value = vars_dict
+    return context
+
+
+class TestResolveVarsRouting:
+    """Tests for _resolve_vars_routing."""
+
+    def test_models_single_folder_match(self):
+        """Matches a model in staging/ to vars.dbt-osmosis.models.staging."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {
+                    "staging": "_stg_{parent}__models.yml",
+                },
+            },
+        })
+        node = _make_node(["project", "staging", "oem_raw", "stg_oem_raw__mme"])
+        result = _resolve_vars_routing(context, node)
+        assert result == "_stg_{parent}__models.yml"
+
+    def test_models_nested_folder_most_specific_wins(self):
+        """When both 'staging' and 'staging.oem_raw' exist, the deeper match wins."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {
+                    "staging": "_stg_{parent}__models.yml",
+                    "staging.oem_raw": "_stg_oem_raw__models.yml",
+                },
+            },
+        })
+        node = _make_node(["project", "staging", "oem_raw", "stg_oem_raw__mme"])
+        result = _resolve_vars_routing(context, node)
+        assert result == "_stg_oem_raw__models.yml"
+
+    def test_models_falls_back_to_parent_folder(self):
+        """Model in staging/oem_raw/ falls back to 'staging' when no 'staging.oem_raw' key."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {
+                    "staging": "_stg_{parent}__models.yml",
+                    "intermediate": "_int_{parent}__models.yml",
+                },
+            },
+        })
+        node = _make_node(["project", "staging", "oem_raw", "stg_oem_raw__mme"])
+        result = _resolve_vars_routing(context, node)
+        assert result == "_stg_{parent}__models.yml"
+
+    def test_models_intermediate_match(self):
+        """Matches intermediate models correctly."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {
+                    "staging": "_stg_{parent}__models.yml",
+                    "intermediate": "_int_{parent}__models.yml",
+                    "marts": "_marts_{parent}__models.yml",
+                },
+            },
+        })
+        node = _make_node(["project", "intermediate", "int_oil_prices"])
+        result = _resolve_vars_routing(context, node)
+        assert result == "_int_{parent}__models.yml"
+
+    def test_models_no_match_returns_none(self):
+        """Returns None when no folder key matches the node's FQN."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {
+                    "staging": "_stg_{parent}__models.yml",
+                },
+            },
+        })
+        node = _make_node(["project", "marts", "fct_oil_price"])
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+    def test_models_empty_routing_returns_none(self):
+        """Returns None when models routing dict is empty."""
+        context = _make_context({"dbt-osmosis": {"models": {}}})
+        node = _make_node(["project", "staging", "my_model"])
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+    def test_models_missing_routing_returns_none(self):
+        """Returns None when vars.dbt-osmosis exists but has no models key."""
+        context = _make_context({"dbt-osmosis": {"sources": {}}})
+        node = _make_node(["project", "staging", "my_model"])
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+    def test_no_osmosis_vars_returns_none(self):
+        """Returns None when vars has no dbt-osmosis section."""
+        context = _make_context({"some_other_var": "value"})
+        node = _make_node(["project", "staging", "my_model"])
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+    def test_underscore_variant_key(self):
+        """Supports dbt_osmosis (underscore) as alternative to dbt-osmosis (kebab)."""
+        context = _make_context({
+            "dbt_osmosis": {
+                "models": {
+                    "staging": "_stg_{parent}__models.yml",
+                },
+            },
+        })
+        node = _make_node(["project", "staging", "oem_raw", "stg_oem_raw__mme"])
+        result = _resolve_vars_routing(context, node)
+        assert result == "_stg_{parent}__models.yml"
+
+    def test_kebab_preferred_over_underscore(self):
+        """When both dbt-osmosis and dbt_osmosis exist, kebab-case wins."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {"staging": "kebab_wins.yml"},
+            },
+            "dbt_osmosis": {
+                "models": {"staging": "underscore_loses.yml"},
+            },
+        })
+        node = _make_node(["project", "staging", "my_model"])
+        result = _resolve_vars_routing(context, node)
+        assert result == "kebab_wins.yml"
+
+    def test_seeds_string_value(self):
+        """Seeds routing with a single string applies to all seeds."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "seeds": "_seeds__models.yml",
+            },
+        })
+        node = _make_node(
+            ["project", "my_seed"],
+            resource_type=NodeType.Seed,
+            name="my_seed",
+        )
+        result = _resolve_vars_routing(context, node)
+        assert result == "_seeds__models.yml"
+
+    def test_seeds_dict_per_folder(self):
+        """Seeds routing with a dict supports per-folder routing."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "seeds": {
+                    "reference": "_ref_seeds.yml",
+                    "test_data": "_test_seeds.yml",
+                },
+            },
+        })
+        node = _make_node(
+            ["project", "reference", "dim_countries"],
+            resource_type=NodeType.Seed,
+            name="dim_countries",
+        )
+        result = _resolve_vars_routing(context, node)
+        assert result == "_ref_seeds.yml"
+
+    def test_seeds_not_matched_for_models(self):
+        """Model nodes do not match against seeds routing."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "seeds": "_seeds__models.yml",
+            },
+        })
+        node = _make_node(["project", "staging", "my_model"], resource_type=NodeType.Model)
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+    def test_models_not_matched_for_seeds(self):
+        """Seed nodes do not match against models routing."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {"staging": "_stg.yml"},
+            },
+        })
+        node = _make_node(["project", "my_seed"], resource_type=NodeType.Seed)
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+    def test_vars_exception_returns_none(self):
+        """Returns None gracefully when vars.to_dict() throws."""
+        context = MagicMock()
+        context.project.runtime_cfg.vars.to_dict.side_effect = RuntimeError("boom")
+        node = _make_node(["project", "staging", "my_model"])
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+    def test_short_fqn_model_at_root(self):
+        """Handles models with only 2 FQN parts (project + model, no folder)."""
+        context = _make_context({
+            "dbt-osmosis": {
+                "models": {"staging": "_stg.yml"},
+            },
+        })
+        node = _make_node(["project", "root_model"])
+        result = _resolve_vars_routing(context, node)
+        assert result is None
+
+
+class TestGetYamlPathTemplateWithVars:
+    """Integration tests: _get_yaml_path_template falls through to vars routing."""
+
+    def test_vars_routing_used_when_config_extra_empty(self, yaml_context):
+        """When a node has no +dbt-osmosis config, vars routing is used."""
+        from dbt_osmosis.core.path_management import _get_yaml_path_template
+
+        node = None
+        for n in yaml_context.project.manifest.nodes.values():
+            if n.resource_type == NodeType.Model and len(n.fqn) > 2:
+                node = n
+                break
+        if not node:
+            pytest.skip("No model with subfolder FQN found in demo_duckdb project")
+
+        # Remove config.extra dbt-osmosis key
+        old_extra = node.config.extra.pop("dbt-osmosis", None)
+        old_unrendered = node.unrendered_config.pop("dbt-osmosis", None)
+        old_meta = node.meta.pop("dbt-osmosis", None)
+
+        # Set up vars routing that matches this node's folder
+        folder = node.fqn[1] if len(node.fqn) > 2 else None
+        if folder:
+            vars_dict = yaml_context.project.runtime_cfg.vars.to_dict()
+            osmosis_vars = vars_dict.setdefault("dbt-osmosis", {})
+            models_routing = osmosis_vars.setdefault("models", {})
+            models_routing[folder] = "_{model}.yml"
+
+            result = _get_yaml_path_template(yaml_context, node)
+            assert result == "_{model}.yml"
+
+            # Cleanup
+            del models_routing[folder]
+            if not models_routing:
+                del osmosis_vars["models"]
+        else:
+            pytest.skip("Model has no folder in FQN")
+
+        # Restore
+        if old_extra is not None:
+            node.config.extra["dbt-osmosis"] = old_extra
+        if old_unrendered is not None:
+            node.unrendered_config["dbt-osmosis"] = old_unrendered
+        if old_meta is not None:
+            node.meta["dbt-osmosis"] = old_meta
+
+    def test_config_extra_takes_priority_over_vars(self, yaml_context):
+        """config.extra +dbt-osmosis still wins over vars routing."""
+        from dbt_osmosis.core.path_management import _get_yaml_path_template
+
+        node = None
+        for n in yaml_context.project.manifest.nodes.values():
+            if (
+                n.resource_type == NodeType.Model
+                and "dbt-osmosis" in n.config.extra
+                and len(n.fqn) > 2
+            ):
+                node = n
+                break
+        if not node:
+            pytest.skip("No model with dbt-osmosis config and subfolder FQN found")
+
+        # Add vars routing for same folder
+        folder = node.fqn[1] if len(node.fqn) > 2 else None
+        if folder:
+            vars_dict = yaml_context.project.runtime_cfg.vars.to_dict()
+            osmosis_vars = vars_dict.setdefault("dbt-osmosis", {})
+            models_routing = osmosis_vars.setdefault("models", {})
+            models_routing[folder] = "vars_should_not_win.yml"
+
+            result = _get_yaml_path_template(yaml_context, node)
+            # config.extra value should win, not vars
+            assert result != "vars_should_not_win.yml"
+
+            # Cleanup
+            del models_routing[folder]
+        else:
+            pytest.skip("Model has no folder in FQN")

--- a/tests/core/test_vars_routing.py
+++ b/tests/core/test_vars_routing.py
@@ -11,16 +11,12 @@ since fusion rejects unknown + prefixed config keys.
 from __future__ import annotations
 
 import typing as t
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from dbt.artifacts.resources.types import NodeType
 
-from dbt_osmosis.core.path_management import (
-    MissingOsmosisConfig,
-    _resolve_vars_routing,
-)
+from dbt_osmosis.core.path_management import _resolve_vars_routing
 
 
 def _make_node(


### PR DESCRIPTION
## Summary

Adds a `vars.dbt-osmosis.models` / `vars.dbt-osmosis.seeds` per-folder routing mechanism as a fusion-compatible alternative to `+dbt-osmosis:` config keys in `dbt_project.yml`.

## Why

dbt-fusion's strict schema validation rejects unknown `+` prefixed keys in `dbt_project.yml`. Existing osmosis users who route YAML via `+dbt-osmosis: "<pattern>"` cannot run their projects through fusion. dbt-core 1.11.8 has also started warning on such custom config keys (`CustomKeyInConfigDeprecation`), so this affects core users too.

Standard `vars:` are accepted by both core and fusion. This PR adds an alternative routing path that lives there.

## What

In `dbt_project.yml`:

```yaml
vars:
  dbt-osmosis:
    models:
      staging: "_stg_{parent}__models.yml"
      "ga4.intermediate": "_ga4_intermediate__models.yml"
      intermediate: "_int_{parent}__models.yml"
    seeds: "_seeds__models.yml"
```

Routing matches against the node's FQN folder path (dot-separated, most specific first). Existing `+dbt-osmosis:` keys still take priority for backward compatibility — nothing breaks for current users.

Tested in real-world Kimball-star projects (oem-dbt-bigquery on BigQuery, polaris-dbt-databricks on Databricks Unity Catalog) and confirmed working with both dbt-core 1.10/1.11 and dbt-fusion 2.0.0-preview.

## Tests

18 new tests in `tests/core/test_vars_routing.py` covering:
- per-folder routing, deepest-match precedence
- both `dbt-osmosis` and `dbt_osmosis` var key spellings
- seeds as string or per-folder dict
- fallback chain (settings resolver → vars routing → global default)
- backward-compat: existing `+dbt-osmosis:` keys win

Full suite: 678 tests passing.

## Docs

- `FUSION_COMPAT.md` — fusion compatibility findings and migration guide
- `docs/docs/tutorial-yaml/configuration.md` — vars routing example

## Resolution order (from `_get_yaml_path_template`)

1. Source definitions (`vars.dbt-osmosis.sources`) for source nodes
2. `SettingsResolver`: `node.config.extra`, `config.meta`, `node.meta`, `unrendered_config`
3. `vars.dbt-osmosis.models` / `.seeds` per-folder routing (new, fusion-compatible)
4. `vars.dbt_osmosis_default_path` global fallback

Existing `+dbt-osmosis:` users are unaffected because the SettingsResolver (step 2) reads the legacy keys before the new vars routing (step 3) is consulted.
